### PR TITLE
fix(wellness): expose missing update_wellness fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `update_wellness` now accepts spO2, vo2max, abdomen, respiration, and menstrualPhase per PRD §7.2.C.
+
 ### Changed
 
 - Refactored internal response shaping to avoid the full response marshal/unmarshal round-trip on normal tool DTOs and consolidate tree walking, with no user-visible output changes.

--- a/internal/intervals/wellness.go
+++ b/internal/intervals/wellness.go
@@ -18,18 +18,18 @@ type WellnessParams struct {
 
 // WriteWellnessParams contains sparse writable wellness fields for one local date.
 type WriteWellnessParams struct {
-	Date         string
-	Feel         *int
-	Fatigue      *int
-	Mood         *int
-	SleepQuality *int
-	Motivation   *int
-	Soreness     *int
-	Stress       *int
-	Weight       *float64
-	BodyFat      *float64
-	Systolic     *int
-	Diastolic    *int
+	Date           string
+	Feel           *int
+	Fatigue        *int
+	Mood           *int
+	SleepQuality   *int
+	Motivation     *int
+	Soreness       *int
+	Stress         *int
+	Weight         *float64
+	BodyFat        *float64
+	Systolic       *int
+	Diastolic      *int
 	BloodGlucose   *float64
 	Lactate        *float64
 	SpO2           *float64

--- a/internal/intervals/wellness.go
+++ b/internal/intervals/wellness.go
@@ -30,12 +30,17 @@ type WriteWellnessParams struct {
 	BodyFat      *float64
 	Systolic     *int
 	Diastolic    *int
-	BloodGlucose *float64
-	Lactate      *float64
-	RestingHR    *int
-	HRV          *float64
-	Injury       *string
-	Locked       *bool
+	BloodGlucose   *float64
+	Lactate        *float64
+	SpO2           *float64
+	VO2Max         *float64
+	Abdomen        *float64
+	Respiration    *float64
+	MenstrualPhase *string
+	RestingHR      *int
+	HRV            *float64
+	Injury         *string
+	Locked         *bool
 }
 
 // Wellness contains typed intervals.icu wellness fields while preserving raw upstream fields.
@@ -167,6 +172,11 @@ func writeWellnessBody(params WriteWellnessParams) (map[string]any, error) {
 	setSparse(body, "diastolic", params.Diastolic)
 	setSparse(body, "bloodGlucose", params.BloodGlucose)
 	setSparse(body, "lactate", params.Lactate)
+	setSparse(body, "spO2", params.SpO2)
+	setSparse(body, "vo2max", params.VO2Max)
+	setSparse(body, "abdomen", params.Abdomen)
+	setSparse(body, "respiration", params.Respiration)
+	setSparse(body, "menstrualPhase", params.MenstrualPhase)
 	setSparse(body, "restingHR", params.RestingHR)
 	setSparse(body, "hrv", params.HRV)
 	setSparse(body, "injury", params.Injury)

--- a/internal/intervals/wellness_test.go
+++ b/internal/intervals/wellness_test.go
@@ -141,6 +141,47 @@ func TestUpdateWellnessSendsSparseBody(t *testing.T) {
 	}
 }
 
+func TestUpdateWellnessSendsNewWritableFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		key    string
+		params WriteWellnessParams
+		want   any
+	}{
+		{name: "spO2", key: "spO2", params: WriteWellnessParams{SpO2: float64Ptr(97)}, want: float64(97)},
+		{name: "vo2max", key: "vo2max", params: WriteWellnessParams{VO2Max: float64Ptr(52.5)}, want: float64(52.5)},
+		{name: "abdomen", key: "abdomen", params: WriteWellnessParams{Abdomen: float64Ptr(81.2)}, want: float64(81.2)},
+		{name: "respiration", key: "respiration", params: WriteWellnessParams{Respiration: float64Ptr(13.5)}, want: float64(13.5)},
+		{name: "menstrualPhase", key: "menstrualPhase", params: WriteWellnessParams{MenstrualPhase: stringPtr("luteal")}, want: "luteal"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("decode request body: %v", err)
+				}
+				if got := body[tc.key]; got != tc.want || len(body) != 1 {
+					t.Fatalf("body = %#v, want sparse %s=%#v update", body, tc.key, tc.want)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"2026-05-01"}`))
+			}))
+			defer server.Close()
+
+			client := newTestClient(t, server.URL, server.Client(), RetryConfig{MaxAttempts: 1})
+			tc.params.Date = "2026-05-01"
+			if _, err := client.UpdateWellness(context.Background(), tc.params); err != nil {
+				t.Fatalf("UpdateWellness() error = %v", err)
+			}
+		})
+	}
+}
+
 func TestListWellnessRequiresOldest(t *testing.T) {
 	t.Parallel()
 
@@ -167,6 +208,14 @@ func TestListWellnessWrapsHTTPError(t *testing.T) {
 	if !strings.Contains(err.Error(), "listing wellness") {
 		t.Fatalf("ListWellness() error = %q, want operation context", err.Error())
 	}
+}
+
+func float64Ptr(value float64) *float64 {
+	return &value
+}
+
+func stringPtr(value string) *string {
+	return &value
 }
 
 func containsString(values []string, want string) bool {

--- a/internal/tools/schema_snapshot/update_wellness.json
+++ b/internal/tools/schema_snapshot/update_wellness.json
@@ -59,6 +59,11 @@
     }
   ],
   "properties": {
+    "abdomen": {
+      "description": "Manual abdomen circumference in cm.",
+      "minimum": 0,
+      "type": "number"
+    },
     "bloodGlucose": {
       "description": "Manual blood glucose in the upstream intervals.icu wellness unit.",
       "minimum": 0,
@@ -114,6 +119,10 @@
       "description": "When true, ask upstream to lock the wellness row against device-sync overwrites.",
       "type": "boolean"
     },
+    "menstrualPhase": {
+      "description": "Menstrual phase as accepted by intervals.icu; free-text string until the upstream enum contract is verified.",
+      "type": "string"
+    },
     "mood": {
       "description": "1-5 (athlete-reported mood); mood scale.",
       "maximum": 5,
@@ -125,6 +134,11 @@
       "maximum": 5,
       "minimum": 1,
       "type": "integer"
+    },
+    "respiration": {
+      "description": "respiration: breaths per minute.",
+      "minimum": 0,
+      "type": "number"
     },
     "restingHR": {
       "description": "Manual resting heart rate in bpm.",
@@ -143,6 +157,12 @@
       "minimum": 1,
       "type": "integer"
     },
+    "spO2": {
+      "description": "spO2: blood oxygen saturation percentage 0-100.",
+      "maximum": 100,
+      "minimum": 0,
+      "type": "number"
+    },
     "stress": {
       "description": "1-5 (athlete-reported stress); stress scale.",
       "maximum": 5,
@@ -153,6 +173,11 @@
       "description": "Manual systolic blood pressure in mmHg.",
       "minimum": 0,
       "type": "integer"
+    },
+    "vo2max": {
+      "description": "vo2max: ml/kg/min.",
+      "minimum": 0,
+      "type": "number"
     },
     "weight": {
       "description": "Manual body weight in the athlete's preferred weight unit from get_athlete_profile (_meta.units / units.weight); converted to upstream kg at the API boundary.",

--- a/internal/tools/update_wellness.go
+++ b/internal/tools/update_wellness.go
@@ -34,16 +34,21 @@ var updateWellnessSubjectiveScaleFields = []string{
 var updateWellnessMeasurementFields = []string{
 	"weight",
 	"bodyFat",
+	"abdomen",
 	"systolic",
 	"diastolic",
 	"bloodGlucose",
 	"lactate",
+	"spO2",
+	"vo2max",
 	"restingHR",
 	"hrv",
+	"respiration",
 }
 
 var updateWellnessFreeTextFields = []string{
 	"injury",
+	"menstrualPhase",
 }
 
 var updateWellnessFlagFields = []string{
@@ -73,11 +78,16 @@ type updateWellnessRequest struct {
 	BodyFat      *float64 `json:"bodyFat,omitempty"`
 	Systolic     *int     `json:"systolic,omitempty"`
 	Diastolic    *int     `json:"diastolic,omitempty"`
-	BloodGlucose *float64 `json:"bloodGlucose,omitempty"`
-	Lactate      *float64 `json:"lactate,omitempty"`
-	RestingHR    *int     `json:"restingHR,omitempty"`
-	HRV          *float64 `json:"hrv,omitempty"`
-	Injury       *string  `json:"injury,omitempty"`
+	BloodGlucose   *float64 `json:"bloodGlucose,omitempty"`
+	Lactate        *float64 `json:"lactate,omitempty"`
+	SpO2           *float64 `json:"spO2,omitempty"`
+	VO2Max         *float64 `json:"vo2max,omitempty"`
+	Abdomen        *float64 `json:"abdomen,omitempty"`
+	Respiration    *float64 `json:"respiration,omitempty"`
+	MenstrualPhase *string  `json:"menstrualPhase,omitempty"`
+	RestingHR      *int     `json:"restingHR,omitempty"`
+	HRV            *float64 `json:"hrv,omitempty"`
+	Injury         *string  `json:"injury,omitempty"`
 	Locked       *bool    `json:"locked,omitempty"`
 	IncludeFull  bool     `json:"include_full,omitempty"`
 }
@@ -200,16 +210,25 @@ func validateUpdateWellnessRanges(args updateWellnessRequest) error {
 		"bodyFat":      args.BodyFat,
 		"bloodGlucose": args.BloodGlucose,
 		"lactate":      args.Lactate,
+		"vo2max":       args.VO2Max,
+		"abdomen":      args.Abdomen,
+		"respiration":  args.Respiration,
 		"hrv":          args.HRV,
 	} {
 		if err := validateFloatMin(field, value, 0); err != nil {
 			return err
 		}
 	}
+	if err := validateFloatRange("spO2", args.SpO2, 0, 100); err != nil {
+		return err
+	}
 	for field, value := range map[string]*int{"systolic": args.Systolic, "diastolic": args.Diastolic, "restingHR": args.RestingHR} {
 		if err := validateIntMin(field, value, 0); err != nil {
 			return err
 		}
+	}
+	if args.MenstrualPhase != nil && strings.TrimSpace(*args.MenstrualPhase) == "" {
+		return errors.New("menstrualPhase must be non-empty")
 	}
 	return nil
 }
@@ -244,6 +263,16 @@ func validateFloatMin(field string, value *float64, min float64) error {
 	return nil
 }
 
+func validateFloatRange(field string, value *float64, min float64, max float64) error {
+	if value == nil {
+		return nil
+	}
+	if *value < min || *value > max {
+		return fmt.Errorf("%s must be %g-%g", field, min, max)
+	}
+	return nil
+}
+
 func wellnessWriteParams(args updateWellnessRequest, profile intervals.AthleteWithSportSettings, timezoneFallback string) (intervals.WriteWellnessParams, updateWellnessMeta) {
 	params := intervals.WriteWellnessParams{
 		Date:         args.Date,
@@ -257,12 +286,17 @@ func wellnessWriteParams(args updateWellnessRequest, profile intervals.AthleteWi
 		BodyFat:      args.BodyFat,
 		Systolic:     args.Systolic,
 		Diastolic:    args.Diastolic,
-		BloodGlucose: args.BloodGlucose,
-		Lactate:      args.Lactate,
-		RestingHR:    args.RestingHR,
-		HRV:          args.HRV,
-		Injury:       args.Injury,
-		Locked:       args.Locked,
+		BloodGlucose:   args.BloodGlucose,
+		Lactate:        args.Lactate,
+		SpO2:           args.SpO2,
+		VO2Max:         args.VO2Max,
+		Abdomen:        args.Abdomen,
+		Respiration:    args.Respiration,
+		MenstrualPhase: args.MenstrualPhase,
+		RestingHR:      args.RestingHR,
+		HRV:            args.HRV,
+		Injury:         args.Injury,
+		Locked:         args.Locked,
 	}
 	meta := updateWellnessMeta{Date: args.Date, Timezone: profileTimezone(profile.Timezone, timezoneFallback), FieldsUpdated: updateWellnessFieldsUpdated(args), IncludeFull: args.IncludeFull}
 	if args.Weight != nil {
@@ -298,6 +332,11 @@ func updateWellnessFieldsUpdated(args updateWellnessRequest) []string {
 	add("diastolic", args.Diastolic != nil)
 	add("bloodGlucose", args.BloodGlucose != nil)
 	add("lactate", args.Lactate != nil)
+	add("spO2", args.SpO2 != nil)
+	add("vo2max", args.VO2Max != nil)
+	add("abdomen", args.Abdomen != nil)
+	add("respiration", args.Respiration != nil)
+	add("menstrualPhase", args.MenstrualPhase != nil)
 	add("restingHR", args.RestingHR != nil)
 	add("hrv", args.HRV != nil)
 	add("injury", args.Injury != nil)
@@ -334,15 +373,20 @@ func updateWellnessInputSchema() map[string]any {
 		"motivation":   scaleSchema(scales, "motivation", 5),
 		"soreness":     scaleSchema(scales, "soreness", 5),
 		"stress":       scaleSchema(scales, "stress", 5),
-		"weight":       map[string]any{"type": "number", "minimum": 0, "description": "Manual body weight in the athlete's preferred weight unit from get_athlete_profile (_meta.units / units.weight); converted to upstream kg at the API boundary."},
-		"bodyFat":      map[string]any{"type": "number", "minimum": 0, "maximum": 100, "description": "Manual body fat percentage, 0-100%."},
-		"systolic":     map[string]any{"type": "integer", "minimum": 0, "description": "Manual systolic blood pressure in mmHg."},
-		"diastolic":    map[string]any{"type": "integer", "minimum": 0, "description": "Manual diastolic blood pressure in mmHg."},
-		"bloodGlucose": map[string]any{"type": "number", "minimum": 0, "description": "Manual blood glucose in the upstream intervals.icu wellness unit."},
-		"lactate":      map[string]any{"type": "number", "minimum": 0, "description": "Manual blood lactate in mmol/L."},
-		"restingHR":    map[string]any{"type": "integer", "minimum": 0, "description": "Manual resting heart rate in bpm."},
-		"hrv":          map[string]any{"type": "number", "minimum": 0, "description": "Manual HRV in milliseconds rMSSD."},
-		"injury":       map[string]any{"type": "string", "description": "Optional free-text injury or limitation note. Preserved verbatim."},
+		"weight":         map[string]any{"type": "number", "minimum": 0, "description": "Manual body weight in the athlete's preferred weight unit from get_athlete_profile (_meta.units / units.weight); converted to upstream kg at the API boundary."},
+		"bodyFat":        map[string]any{"type": "number", "minimum": 0, "maximum": 100, "description": "Manual body fat percentage, 0-100%."},
+		"abdomen":        map[string]any{"type": "number", "minimum": 0, "description": "Manual abdomen circumference in cm."},
+		"systolic":       map[string]any{"type": "integer", "minimum": 0, "description": "Manual systolic blood pressure in mmHg."},
+		"diastolic":      map[string]any{"type": "integer", "minimum": 0, "description": "Manual diastolic blood pressure in mmHg."},
+		"bloodGlucose":   map[string]any{"type": "number", "minimum": 0, "description": "Manual blood glucose in the upstream intervals.icu wellness unit."},
+		"lactate":        map[string]any{"type": "number", "minimum": 0, "description": "Manual blood lactate in mmol/L."},
+		"spO2":           map[string]any{"type": "number", "minimum": 0, "maximum": 100, "description": "spO2: blood oxygen saturation percentage 0-100."},
+		"vo2max":         map[string]any{"type": "number", "minimum": 0, "description": "vo2max: ml/kg/min."},
+		"restingHR":      map[string]any{"type": "integer", "minimum": 0, "description": "Manual resting heart rate in bpm."},
+		"hrv":            map[string]any{"type": "number", "minimum": 0, "description": "Manual HRV in milliseconds rMSSD."},
+		"respiration":    map[string]any{"type": "number", "minimum": 0, "description": "respiration: breaths per minute."},
+		"menstrualPhase": map[string]any{"type": "string", "description": "Menstrual phase as accepted by intervals.icu; free-text string until the upstream enum contract is verified."},
+		"injury":         map[string]any{"type": "string", "description": "Optional free-text injury or limitation note. Preserved verbatim."},
 		"locked":       map[string]any{"type": "boolean", "description": "When true, ask upstream to lock the wellness row against device-sync overwrites."},
 		"include_full": map[string]any{"type": "boolean", "default": false, "description": "When true, include the raw upstream wellness row under wellness.full and keep null fields."},
 	}}

--- a/internal/tools/update_wellness.go
+++ b/internal/tools/update_wellness.go
@@ -66,18 +66,18 @@ type WellnessWriterClient interface {
 }
 
 type updateWellnessRequest struct {
-	Date         string   `json:"date"`
-	Feel         *int     `json:"feel,omitempty"`
-	Fatigue      *int     `json:"fatigue,omitempty"`
-	Mood         *int     `json:"mood,omitempty"`
-	SleepQuality *int     `json:"sleepQuality,omitempty"`
-	Motivation   *int     `json:"motivation,omitempty"`
-	Soreness     *int     `json:"soreness,omitempty"`
-	Stress       *int     `json:"stress,omitempty"`
-	Weight       *float64 `json:"weight,omitempty"`
-	BodyFat      *float64 `json:"bodyFat,omitempty"`
-	Systolic     *int     `json:"systolic,omitempty"`
-	Diastolic    *int     `json:"diastolic,omitempty"`
+	Date           string   `json:"date"`
+	Feel           *int     `json:"feel,omitempty"`
+	Fatigue        *int     `json:"fatigue,omitempty"`
+	Mood           *int     `json:"mood,omitempty"`
+	SleepQuality   *int     `json:"sleepQuality,omitempty"`
+	Motivation     *int     `json:"motivation,omitempty"`
+	Soreness       *int     `json:"soreness,omitempty"`
+	Stress         *int     `json:"stress,omitempty"`
+	Weight         *float64 `json:"weight,omitempty"`
+	BodyFat        *float64 `json:"bodyFat,omitempty"`
+	Systolic       *int     `json:"systolic,omitempty"`
+	Diastolic      *int     `json:"diastolic,omitempty"`
 	BloodGlucose   *float64 `json:"bloodGlucose,omitempty"`
 	Lactate        *float64 `json:"lactate,omitempty"`
 	SpO2           *float64 `json:"spO2,omitempty"`
@@ -88,8 +88,8 @@ type updateWellnessRequest struct {
 	RestingHR      *int     `json:"restingHR,omitempty"`
 	HRV            *float64 `json:"hrv,omitempty"`
 	Injury         *string  `json:"injury,omitempty"`
-	Locked       *bool    `json:"locked,omitempty"`
-	IncludeFull  bool     `json:"include_full,omitempty"`
+	Locked         *bool    `json:"locked,omitempty"`
+	IncludeFull    bool     `json:"include_full,omitempty"`
 }
 
 type updateWellnessResponse struct {
@@ -275,17 +275,17 @@ func validateFloatRange(field string, value *float64, min float64, max float64) 
 
 func wellnessWriteParams(args updateWellnessRequest, profile intervals.AthleteWithSportSettings, timezoneFallback string) (intervals.WriteWellnessParams, updateWellnessMeta) {
 	params := intervals.WriteWellnessParams{
-		Date:         args.Date,
-		Feel:         args.Feel,
-		Fatigue:      args.Fatigue,
-		Mood:         args.Mood,
-		SleepQuality: args.SleepQuality,
-		Motivation:   args.Motivation,
-		Soreness:     args.Soreness,
-		Stress:       args.Stress,
-		BodyFat:      args.BodyFat,
-		Systolic:     args.Systolic,
-		Diastolic:    args.Diastolic,
+		Date:           args.Date,
+		Feel:           args.Feel,
+		Fatigue:        args.Fatigue,
+		Mood:           args.Mood,
+		SleepQuality:   args.SleepQuality,
+		Motivation:     args.Motivation,
+		Soreness:       args.Soreness,
+		Stress:         args.Stress,
+		BodyFat:        args.BodyFat,
+		Systolic:       args.Systolic,
+		Diastolic:      args.Diastolic,
 		BloodGlucose:   args.BloodGlucose,
 		Lactate:        args.Lactate,
 		SpO2:           args.SpO2,
@@ -365,14 +365,14 @@ func updateWellnessInputSchema() map[string]any {
 	scales := response.RegisteredScaleLabels()
 	examples := updateWellnessInputExamples()
 	return map[string]any{"type": "object", "additionalProperties": false, "required": []string{"date"}, "examples": examples, "input_examples": examples, "properties": map[string]any{
-		"date":         map[string]any{"type": "string", "description": "Required athlete-local wellness date as YYYY-MM-DD."},
-		"feel":         scaleSchema(scales, "feel", 5),
-		"fatigue":      scaleSchema(scales, "fatigue", 5),
-		"mood":         scaleSchema(scales, "mood", 5),
-		"sleepQuality": scaleSchema(scales, "sleepQuality", 4),
-		"motivation":   scaleSchema(scales, "motivation", 5),
-		"soreness":     scaleSchema(scales, "soreness", 5),
-		"stress":       scaleSchema(scales, "stress", 5),
+		"date":           map[string]any{"type": "string", "description": "Required athlete-local wellness date as YYYY-MM-DD."},
+		"feel":           scaleSchema(scales, "feel", 5),
+		"fatigue":        scaleSchema(scales, "fatigue", 5),
+		"mood":           scaleSchema(scales, "mood", 5),
+		"sleepQuality":   scaleSchema(scales, "sleepQuality", 4),
+		"motivation":     scaleSchema(scales, "motivation", 5),
+		"soreness":       scaleSchema(scales, "soreness", 5),
+		"stress":         scaleSchema(scales, "stress", 5),
 		"weight":         map[string]any{"type": "number", "minimum": 0, "description": "Manual body weight in the athlete's preferred weight unit from get_athlete_profile (_meta.units / units.weight); converted to upstream kg at the API boundary."},
 		"bodyFat":        map[string]any{"type": "number", "minimum": 0, "maximum": 100, "description": "Manual body fat percentage, 0-100%."},
 		"abdomen":        map[string]any{"type": "number", "minimum": 0, "description": "Manual abdomen circumference in cm."},
@@ -387,8 +387,8 @@ func updateWellnessInputSchema() map[string]any {
 		"respiration":    map[string]any{"type": "number", "minimum": 0, "description": "respiration: breaths per minute."},
 		"menstrualPhase": map[string]any{"type": "string", "description": "Menstrual phase as accepted by intervals.icu; free-text string until the upstream enum contract is verified."},
 		"injury":         map[string]any{"type": "string", "description": "Optional free-text injury or limitation note. Preserved verbatim."},
-		"locked":       map[string]any{"type": "boolean", "description": "When true, ask upstream to lock the wellness row against device-sync overwrites."},
-		"include_full": map[string]any{"type": "boolean", "default": false, "description": "When true, include the raw upstream wellness row under wellness.full and keep null fields."},
+		"locked":         map[string]any{"type": "boolean", "description": "When true, ask upstream to lock the wellness row against device-sync overwrites."},
+		"include_full":   map[string]any{"type": "boolean", "default": false, "description": "When true, include the raw upstream wellness row under wellness.full and keep null fields."},
 	}}
 }
 

--- a/internal/tools/update_wellness_test.go
+++ b/internal/tools/update_wellness_test.go
@@ -98,7 +98,9 @@ func TestUpdateWellnessNewFieldsRoundTripToParamsAndFieldsUpdated(t *testing.T) 
 		{name: "vo2max", raw: `{"date":"2026-05-01","vo2max":52.5}`, field: "vo2max", wantParam: func(p intervals.WriteWellnessParams) bool { return p.VO2Max != nil && *p.VO2Max == 52.5 }},
 		{name: "abdomen", raw: `{"date":"2026-05-01","abdomen":81.2}`, field: "abdomen", wantParam: func(p intervals.WriteWellnessParams) bool { return p.Abdomen != nil && *p.Abdomen == 81.2 }},
 		{name: "respiration", raw: `{"date":"2026-05-01","respiration":13.5}`, field: "respiration", wantParam: func(p intervals.WriteWellnessParams) bool { return p.Respiration != nil && *p.Respiration == 13.5 }},
-		{name: "menstrualPhase", raw: `{"date":"2026-05-01","menstrualPhase":"luteal"}`, field: "menstrualPhase", wantParam: func(p intervals.WriteWellnessParams) bool { return p.MenstrualPhase != nil && *p.MenstrualPhase == "luteal" }},
+		{name: "menstrualPhase", raw: `{"date":"2026-05-01","menstrualPhase":"luteal"}`, field: "menstrualPhase", wantParam: func(p intervals.WriteWellnessParams) bool {
+			return p.MenstrualPhase != nil && *p.MenstrualPhase == "luteal"
+		}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/tools/update_wellness_test.go
+++ b/internal/tools/update_wellness_test.go
@@ -68,6 +68,11 @@ func TestUpdateWellnessRejectsOutOfRangeAndReadOnlyArgumentsBeforeWrite(t *testi
 		`{"date":"2026-05-01","feel":6}`,
 		`{"date":"2026-05-01","sleepQuality":5}`,
 		`{"date":"2026-05-01","bodyFat":-1}`,
+		`{"date":"2026-05-01","spO2":200}`,
+		`{"date":"2026-05-01","vo2max":-1}`,
+		`{"date":"2026-05-01","abdomen":-1}`,
+		`{"date":"2026-05-01","respiration":-1}`,
+		`{"date":"2026-05-01","menstrualPhase":""}`,
 		`{"date":"2026-05-01","sleepScore":88}`,
 		`{"date":"2026-05-01","_native":{"polar":{"sleep_score":90}}}`,
 	} {
@@ -77,6 +82,74 @@ func TestUpdateWellnessRejectsOutOfRangeAndReadOnlyArgumentsBeforeWrite(t *testi
 	}
 	if len(client.calls) != 0 {
 		t.Fatalf("write calls = %#v, want none after validation failures", client.calls)
+	}
+}
+
+func TestUpdateWellnessNewFieldsRoundTripToParamsAndFieldsUpdated(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		raw       string
+		field     string
+		wantParam func(intervals.WriteWellnessParams) bool
+	}{
+		{name: "spO2", raw: `{"date":"2026-05-01","spO2":97}`, field: "spO2", wantParam: func(p intervals.WriteWellnessParams) bool { return p.SpO2 != nil && *p.SpO2 == 97 }},
+		{name: "vo2max", raw: `{"date":"2026-05-01","vo2max":52.5}`, field: "vo2max", wantParam: func(p intervals.WriteWellnessParams) bool { return p.VO2Max != nil && *p.VO2Max == 52.5 }},
+		{name: "abdomen", raw: `{"date":"2026-05-01","abdomen":81.2}`, field: "abdomen", wantParam: func(p intervals.WriteWellnessParams) bool { return p.Abdomen != nil && *p.Abdomen == 81.2 }},
+		{name: "respiration", raw: `{"date":"2026-05-01","respiration":13.5}`, field: "respiration", wantParam: func(p intervals.WriteWellnessParams) bool { return p.Respiration != nil && *p.Respiration == 13.5 }},
+		{name: "menstrualPhase", raw: `{"date":"2026-05-01","menstrualPhase":"luteal"}`, field: "menstrualPhase", wantParam: func(p intervals.WriteWellnessParams) bool { return p.MenstrualPhase != nil && *p.MenstrualPhase == "luteal" }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &fakeWellnessWriterClient{
+				fakeProfileClient: fakeProfileClient{profile: intervals.AthleteWithSportSettings{PreferredUnits: "metric", Timezone: "UTC"}},
+				row:               decodeWellnessRow(t, `{"id":"2026-05-01"}`),
+			}
+			tool := newUpdateWellnessTool(client, client, "test", "UTC", false)
+
+			result, err := tool.Handler(context.Background(), Request{Name: tool.Name, Arguments: json.RawMessage(tc.raw)})
+			if err != nil {
+				t.Fatalf("Handler() error = %v", err)
+			}
+			if len(client.calls) != 1 || !tc.wantParam(client.calls[0]) {
+				t.Fatalf("write calls = %#v, want %s update", client.calls, tc.field)
+			}
+			meta := resultMap(t, result)["_meta"].(map[string]any)
+			if !containsAny(meta["fields_updated"].([]any), tc.field) {
+				t.Fatalf("fields_updated = %#v, want %s", meta["fields_updated"], tc.field)
+			}
+		})
+	}
+}
+
+func TestUpdateWellnessWritesAllNewFieldsTogether(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeWellnessWriterClient{
+		fakeProfileClient: fakeProfileClient{profile: intervals.AthleteWithSportSettings{PreferredUnits: "metric", Timezone: "UTC"}},
+		row:               decodeWellnessRow(t, `{"id":"2026-05-01"}`),
+	}
+	tool := newUpdateWellnessTool(client, client, "test", "UTC", false)
+
+	result, err := tool.Handler(context.Background(), Request{Name: tool.Name, Arguments: json.RawMessage(`{"date":"2026-05-01","spO2":98,"vo2max":54.1,"abdomen":80.2,"respiration":12.5,"menstrualPhase":"follicular"}`)})
+	if err != nil {
+		t.Fatalf("Handler() error = %v", err)
+	}
+	if len(client.calls) != 1 {
+		t.Fatalf("write calls = %d, want 1", len(client.calls))
+	}
+	call := client.calls[0]
+	if call.SpO2 == nil || *call.SpO2 != 98 || call.VO2Max == nil || *call.VO2Max != 54.1 || call.Abdomen == nil || *call.Abdomen != 80.2 || call.Respiration == nil || *call.Respiration != 12.5 || call.MenstrualPhase == nil || *call.MenstrualPhase != "follicular" {
+		t.Fatalf("write call = %#v, want all new fields", call)
+	}
+	fields := resultMap(t, result)["_meta"].(map[string]any)["fields_updated"].([]any)
+	for _, field := range []string{"spO2", "vo2max", "abdomen", "respiration", "menstrualPhase"} {
+		if !containsAny(fields, field) {
+			t.Fatalf("fields_updated = %#v, want %s", fields, field)
+		}
 	}
 }
 

--- a/taskplane-tasks/TP-050-hugo-hextra-site-scaffold/PROMPT.md
+++ b/taskplane-tasks/TP-050-hugo-hextra-site-scaffold/PROMPT.md
@@ -1,0 +1,160 @@
+# TP-050 — Hugo + Hextra site scaffold with Pagefind search
+
+## Mission
+
+Replace the current single-page Hugo site at `web/` with a structured documentation site built on the [Hextra](https://imfing.github.io/hextra/) theme, organized along Diataxis lines (tutorials / how-to / reference / explanation), with Pagefind static search. This is the foundation for moving end-user documentation off GitHub and onto **icuvisor.app**, so that the GitHub repo can host developer-/contributor-facing material only.
+
+This task lands the **scaffold + theme + navigation + search + deploy pipeline only**. Content migration is TP-052; the tool-catalog generator is TP-051; the getting-started tutorial is TP-053; the README rewrite is TP-054.
+
+Project context (icuvisor is currently private, no external links to break, no migration notices needed):
+
+- Today `web/` is a hand-rolled single page (`layouts/index.html` + `static/css/style.css`) plus a stub `content/_index.md`. Deploy is via `.github/workflows/pages.yml` to GitHub Pages with custom domain `icuvisor.app` (CNAME in `static/`).
+- Hugo version pinned in workflow: `0.139.4` extended. Hextra requires Hugo extended ≥ 0.134; keep the pinned version unless Hextra needs newer.
+
+PRD anchors: §7.4 KR1 (install success / discoverability), §6 KR5 (token efficiency — long-form content lives off-binary, on the website).
+
+ROADMAP positioning: docs polish supporting v0.5 internal beta and v1.0 public launch.
+
+Complexity: Blast radius 2 (web/ only, no Go code), Pattern novelty 3 (first time using Hextra in this repo), Security 1, Reversibility 2 = 8 → Review Level 2. Size: M.
+
+## Dependencies
+
+None blocking. The other doc-refactor tasks (TP-051, TP-052, TP-053, TP-054) depend on this landing first.
+
+## Context to Read First
+
+- `web/hugo.toml`, `web/layouts/index.html`, `web/static/css/style.css`, `web/content/_index.md`, `web/README.md`
+- `.github/workflows/pages.yml`
+- `CLAUDE.md` (esp. "no emojis in commits/PRs" and Conventional Commits rules)
+- Hextra docs: <https://imfing.github.io/hextra/docs/> — installation as a Hugo Module is the recommended path.
+- Pagefind: <https://pagefind.app/docs/> — Hextra has built-in Pagefind integration; verify which knob enables it.
+- Diataxis overview already captured in this taskplane PR's source plan (tutorials / how-to / reference / explanation).
+
+## File Scope
+
+Expected files (new unless noted):
+
+- `web/hugo.toml` — extend with Hextra module import, menu config, params for theme, Pagefind enabled.
+- `web/go.mod`, `web/go.sum` — Hugo Modules manifests for the Hextra dependency.
+- `web/content/_index.md` — keep as landing page; either retain the bespoke `layouts/index.html` for the landing only (Hextra supports per-page layout overrides) **or** rebuild the landing with Hextra's hero/feature shortcodes. Pick one and justify in `STATUS.md`. The bespoke landing has design value (see `static/css/style.css` — design tokens from `.claude/skills/design-system/`); preserving it is preferred if Hextra allows a clean override.
+- `web/content/install/_index.md` — section landing with frontmatter only (empty body; content is TP-052).
+- `web/content/connect/_index.md`
+- `web/content/guides/_index.md`
+- `web/content/reference/_index.md`
+- `web/content/explain/_index.md`
+- `web/content/tutorials/_index.md`
+- `web/layouts/index.html` — keep or remove depending on landing decision above.
+- `web/layouts/partials/` — any small overrides Hextra needs (e.g., custom footer matching current "MIT-licensed · not affiliated with intervals.icu" line).
+- `web/static/CNAME` — keep as-is.
+- `web/static/favicon.svg` — keep if present.
+- `.github/workflows/pages.yml` — add a `hugo mod get` / `hugo mod tidy` step before `hugo --minify --gc`. Confirm Pagefind index is built (Hextra runs Pagefind at build time when enabled).
+- `web/README.md` — update local-preview instructions for Hugo Modules (e.g., `hugo mod get -u`, then `hugo server`).
+- `taskplane-tasks/TP-050-hugo-hextra-site-scaffold/STATUS.md`.
+
+Out of scope:
+
+- Tool-catalog data file (`web/data/tools.json`) — TP-051.
+- Any content under `install/`, `connect/`, `guides/`, `reference/`, `explain/`, `tutorials/` beyond the empty section indexes — TP-052 and TP-053.
+- README rewrite — TP-054.
+- Deleting `docs/*.md` files migrated elsewhere — TP-052 and TP-054.
+
+## Steps
+
+### Step 1: Decide on landing-page strategy
+
+- [ ] Read `web/layouts/index.html` and `web/static/css/style.css`. Decide:
+  - **(A)** Keep the bespoke landing page exactly as-is by setting `layout` / `type` on `content/_index.md` so Hextra renders the home page through the existing layout. Hextra still owns every other page.
+  - **(B)** Rebuild the landing using Hextra's hero/feature shortcodes for consistency.
+- [ ] Default recommendation: **(A)**. The bespoke landing has explicit design-system styling that Hextra's defaults will not match, and rebuilding it is design work, not docs work. Only choose (B) if (A) requires fighting Hextra.
+- [ ] Record the choice and rationale in `STATUS.md`.
+
+### Step 2: Install Hextra as a Hugo Module
+
+- [ ] `cd web && hugo mod init github.com/ricardocabral/icuvisor/web`.
+- [ ] Add the Hextra module import to `hugo.toml`:
+  ```toml
+  [module]
+    [[module.imports]]
+      path = "github.com/imfing/hextra"
+  ```
+- [ ] `hugo mod get -u github.com/imfing/hextra`.
+- [ ] Verify `go.mod` and `go.sum` are committed.
+- [ ] Confirm Hextra version pinning strategy — pin to a released tag, not `latest`, so the site does not silently break. Record the chosen version in `STATUS.md`.
+
+### Step 3: Configure navigation, theme params, Pagefind
+
+- [ ] `hugo.toml`: declare top-level menu (Install · Connect · Guides · Tutorials · Reference · Explain · GitHub). The GitHub entry links to <https://github.com/ricardocabral/icuvisor>.
+- [ ] Enable Pagefind. Hextra exposes a `search.enable` (or equivalent — confirm against Hextra docs) param. Verify search UI appears in the rendered header.
+- [ ] Set theme params consistent with the current brand: site title (`icuvisor — Talk to your intervals.icu data`), description (current value in `hugo.toml`), favicon, primary colour roughly matching `--primary` from `static/css/style.css`.
+- [ ] Keep `enableRobotsTXT = true`. Keep `disableKinds` minimal; Hextra may want `taxonomy`/`term` enabled — verify before disabling.
+- [ ] Configure footer to keep the line "MIT-licensed · not affiliated with intervals.icu" and links to GitHub, SECURITY.md, CONTRIBUTING.md.
+
+### Step 4: Create empty section indexes
+
+- [ ] Add `_index.md` files for the five Diataxis sections under `web/content/`. Each has only frontmatter (title, weight, optional `cascade` to set Hextra display options for the section). Body is intentionally empty; populated by TP-052/053.
+- [ ] Section weights: `install=10`, `connect=20`, `tutorials=30`, `guides=40`, `reference=50`, `explain=60`. So navigation reads left-to-right: Install → Connect → Tutorials → Guides → Reference → Explain.
+
+### Step 5: Pages workflow
+
+- [ ] Update `.github/workflows/pages.yml`:
+  - Before `hugo --minify --gc`, run `hugo mod get` (and optionally `hugo mod tidy`).
+  - Confirm Pagefind output ends up under `web/public/` so the deploy artifact includes it. Hextra runs Pagefind automatically when enabled; if not, add an explicit `npx pagefind --site public` step after the Hugo build.
+  - Keep the deploy job unchanged.
+- [ ] Add a smoke step: `test -f web/public/index.html && test -d web/public/pagefind` (or equivalent) so a broken search index fails the build.
+
+### Step 6: Local preview docs
+
+- [ ] Rewrite `web/README.md` for the Hugo-Modules workflow:
+  ```bash
+  cd web
+  hugo mod get -u
+  hugo server -D
+  ```
+- [ ] Note the minimum Hugo extended version, where the Hextra version is pinned, and how to upgrade Hextra (`hugo mod get -u github.com/imfing/hextra@<tag>`).
+
+### Step 7: Verify
+
+- [ ] `cd web && hugo --minify --gc` builds cleanly with zero warnings.
+- [ ] `hugo server -D` renders the landing, all five section indexes (even empty), and the search box.
+- [ ] Pagefind index is generated under `web/public/pagefind/`.
+- [ ] `.github/workflows/pages.yml` passes locally via `act` (optional) or via a PR preview if available.
+- [ ] No broken internal links (`hugo` build will warn on these; promote warnings to errors via `--printPathWarnings` or equivalent if Hextra supports it).
+
+## Acceptance Criteria
+
+- `web/` builds via Hugo Modules with Hextra as the theme and Pagefind enabled.
+- Landing page renders with current branding (either via preserved bespoke layout or via Hextra shortcodes — whichever was chosen).
+- Top-level menu shows: Install, Connect, Tutorials, Guides, Reference, Explain, GitHub.
+- Five empty section index pages exist with correct frontmatter; navigation lists each section.
+- Pagefind search box is present in the site header and produces a static index under `public/pagefind/` at build time.
+- `.github/workflows/pages.yml` builds the new site successfully, including the Hextra module fetch and Pagefind index.
+- `web/README.md` documents the new local-preview workflow.
+- No regression in deploy: `https://icuvisor.app/` still serves a valid landing page.
+
+## Do NOT
+
+- Do not add any end-user documentation content in this task — section indexes stay empty. Content lands in TP-052 / TP-053.
+- Do not delete `docs/*.md` files in this task — handled by TP-052 / TP-054.
+- Do not commit a Hugo theme as a vendored copy under `web/themes/`. Use Hugo Modules.
+- Do not pin Hextra to `latest`; pin to a tagged release.
+- Do not introduce a JavaScript build step (npm install, webpack, etc.) unless Pagefind requires it. Prefer the Hugo-Modules-only path.
+- Do not change the GitHub Pages deploy target or the CNAME.
+- Do not add emojis to commits, PR descriptions, or rendered site content (per CLAUDE.md).
+
+## Documentation
+
+Must update:
+
+- `STATUS.md` — landing-page strategy decision, Hextra version pinned, Pagefind verification notes.
+- `web/README.md` — local-preview instructions.
+- `CHANGELOG.md` under `[Unreleased]` if the live site URL changes user-visible behaviour (unlikely for scaffolding; if added, mention "Site now built with Hextra theme and full-text search.").
+
+## Git Commit Convention
+
+Commit at step boundaries with messages prefixed by `TP-050`, for example: `TP-050 add Hextra Hugo module and section indexes`. Conventional Commits, lowercase imperative subject.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-050-hugo-hextra-site-scaffold/STATUS.md
+++ b/taskplane-tasks/TP-050-hugo-hextra-site-scaffold/STATUS.md
@@ -1,0 +1,39 @@
+# TP-050-hugo-hextra-site-scaffold — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** M
+
+---
+
+### Step 1: Decide on landing-page strategy
+
+**Status:** ⏳ Pending
+
+### Step 2: Install Hextra as a Hugo Module
+
+**Status:** ⏳ Pending
+
+### Step 3: Configure navigation, theme params, Pagefind
+
+**Status:** ⏳ Pending
+
+### Step 4: Create empty section indexes
+
+**Status:** ⏳ Pending
+
+### Step 5: Pages workflow
+
+**Status:** ⏳ Pending
+
+### Step 6: Local preview docs
+
+**Status:** ⏳ Pending
+
+### Step 7: Verify
+
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-055-reconcile-doc-conflicts/PROMPT.md
+++ b/taskplane-tasks/TP-055-reconcile-doc-conflicts/PROMPT.md
@@ -1,0 +1,155 @@
+# TP-055 — Reconcile three documentation conflicts
+
+## Mission
+
+Resolve three documentation conflicts that currently exist between the PRD, ROADMAP, README, and the implemented code. These are not migration artifacts — they predate the website refactor and would silently propagate into the new Hugo site if not fixed first. Each conflict has a concrete remediation; pick the right one per conflict and land it.
+
+The three conflicts (verify each against the current code at the time of execution — do not trust the line numbers in this prompt blindly; they were captured on 2026-05-16):
+
+### Conflict A — Analyzer family ghost
+
+- `docs/prd/PRD-icuvisor.md` §7.2.C (around lines 276–320) declares an analyzer family (`analyze_*`, `compute_*`, `get_fitness_projection`) and a "~39 tools at v1.0" target.
+- `README.md` (around lines 35–74) lists ~36 tools, **none** of them analyzers.
+- `internal/tools/registry.go` (around lines 117–236) registers **zero** analyzers.
+- `ROADMAP.md` does not mention an analyzer phase.
+
+**Decision required:** Either (a) **defer in PRD** — move the analyzer family to "vNext / out of scope for v1" in `docs/prd/PRD-icuvisor.md`, drop the "~39 tools" target to match reality, and explain the rationale in a one-paragraph PRD changelog entry; **or** (b) **add a roadmap phase** — write a `## v0.6 — Analyzers` (or similar) section in `ROADMAP.md` with scope, deliverables, and rough phasing, and keep the PRD as-is.
+
+Recommendation: **(a) defer in PRD**. Rationale: there is no implementation, no taskplane TP for an analyzer family, and no recent ROADMAP signal that this work is imminent. Deferring is the honest reflection of priorities; the family can re-enter the PRD if/when a TP gets queued. The executing agent must record the decision and the reasoning in `STATUS.md`. Get human sign-off before executing if uncertain.
+
+### Conflict B — `get_planning_parameters` ROADMAP contradiction
+
+- `ROADMAP.md` line ~22 lists `get_planning_parameters` as **checked off**.
+- `ROADMAP.md` line ~29 lists it as **deferred**.
+
+These cannot both be true. Inspect the tool registry to determine the truth:
+
+- If `get_planning_parameters` **is registered** in `internal/tools/`, keep the checked-off line and **delete** the deferred line.
+- If it **is not registered**, keep the deferred line and **delete** the checked-off line.
+- If it is registered but the surface differs from the original ROADMAP description, fix both ROADMAP entries to match what the code actually does.
+
+The README must also reflect this. If the tool is registered, it should appear in the README's tool list (and, after TP-051, in the generated catalog). If it is not, no README mention.
+
+### Conflict C — `update_wellness` error contract not surfaced
+
+- `docs/prd/PRD-icuvisor.md` line ~247 specifies that `update_wellness` returns `field_not_writable: sleepScore (device-managed)` when callers attempt to write device-owned fields.
+- `README.md` `update_wellness` bullet describes the device-rejection behaviour in prose ("rejecting device-owned `sleepScore`/`_native` fields") but does not surface the `field_not_writable` **error code** an MCP client or test fixture would see.
+- The website's reference page for `update_wellness` (landing under TP-052) must show the error contract so end users and integrators understand what to expect on a rejection.
+
+**Decision required:** This is not a contradiction — it is missing user-facing documentation. The fix:
+
+- Verify the actual error code emitted by `update_wellness` against `internal/tools/update_wellness.go`. The PRD's `field_not_writable` may or may not match the implementation's literal error string. **Code wins; update the PRD if needed.**
+- Ensure the error contract appears on the website at `/reference/tools/#update_wellness` (the generator from TP-051 should pick this up automatically if the tool's MCP description includes the error in the summary; if not, the generator's `ToolDescriptor` may need an `errors` field — file a TP-051 amendment if so).
+- Ensure the same error contract is captured in the README replacement on the website's `/reference/safety-modes/` or `/reference/tools/` page (whichever TP-052 chose for tool error contracts).
+
+PRD anchors: §7.2.C catalog truthfulness, §7.4 #11 (schema/catalog stability), §6 KR5 (token efficiency).
+
+ROADMAP positioning: doc-truth cleanup. No new user-visible capability.
+
+Complexity: Blast radius 2 (PRD, ROADMAP, README, possibly tool registry metadata), Pattern novelty 1, Security 1, Reversibility 2 = 6 → Review Level 2. Size: S.
+
+## Dependencies
+
+- None. This task can land before, during, or after TP-050–054.
+- **Recommended order:** TP-055 lands **before** TP-051 and TP-052 so the generator and migration consume corrected content.
+
+## Context to Read First
+
+- `CLAUDE.md`
+- `docs/prd/PRD-icuvisor.md` §7.2.C and the line referenced for Conflict C.
+- `ROADMAP.md` (the full file — the two `get_planning_parameters` lines are not adjacent).
+- `README.md` §"MCP tool catalog".
+- `internal/tools/registry.go` — confirm which tools are actually registered.
+- `internal/tools/update_wellness.go` — confirm error code literal.
+- `CHANGELOG.md`
+
+## File Scope
+
+Expected files:
+
+- `docs/prd/PRD-icuvisor.md` — analyzer-family deferral (or, if (b) chosen, leave alone); possibly `update_wellness` error-code wording.
+- `ROADMAP.md` — resolve the `get_planning_parameters` contradiction; possibly add a `v0.6 Analyzers` section (only if Conflict A choice is (b)).
+- `README.md` — reflect ROADMAP/PRD truth for `get_planning_parameters` and `update_wellness` error.
+- `internal/tools/update_wellness.go` — only if the error literal needs to change to match the documented contract; otherwise leave code alone and align docs to code.
+- `CHANGELOG.md` — `[Unreleased]` under "Changed" / "Fixed" as appropriate.
+- `taskplane-tasks/TP-055-reconcile-doc-conflicts/STATUS.md`.
+
+Out of scope:
+
+- Implementing the analyzer family (always out of scope for this task, regardless of Conflict A decision).
+- Migrating end-user content to the website — TP-052.
+- README slim-down — TP-054.
+
+## Steps
+
+### Step 1: Re-verify all three conflicts against the current tree
+
+- [ ] Re-read PRD §7.2.C and confirm the analyzer-family entry and tool-count target.
+- [ ] Confirm `internal/tools/registry.go` registers zero analyzers.
+- [ ] Confirm both `get_planning_parameters` ROADMAP lines still exist and still contradict.
+- [ ] Read `internal/tools/update_wellness.go` and capture the **exact** error literal returned when `sleepScore` is written.
+- [ ] Record findings in `STATUS.md` Step 1 with file paths and current line numbers.
+
+### Step 2: Resolve Conflict A (analyzer family)
+
+- [ ] Choose (a) defer in PRD or (b) add roadmap phase. Default: (a). Justify in `STATUS.md`.
+- [ ] (a): edit PRD §7.2.C — move analyzer family to a new "Deferred" subsection or to `vNext`; drop the "~39 tools" target to a realistic current number (or remove the count entirely and let the catalog be the truth); add a brief in-PRD note: "Analyzer family deferred; see CHANGELOG `[Unreleased]`."
+- [ ] (b): edit `ROADMAP.md` — add a `## v0.6 — Analyzers` section (or appropriate version) listing the family, brief scope, and signal that it depends on the read-side fitness/efforts tools already shipped.
+
+### Step 3: Resolve Conflict B (`get_planning_parameters`)
+
+- [ ] Inspect registry; determine truth.
+- [ ] Edit `ROADMAP.md` to remove the contradicting line. Keep one consistent statement.
+- [ ] Update `README.md`'s tool list to match. (Note: TP-051 will subsequently replace the hand-list with a generator; this task only ensures the current README is consistent.)
+
+### Step 4: Resolve Conflict C (`update_wellness` error contract)
+
+- [ ] Confirm the error literal in code.
+- [ ] If PRD wording does not match code, update the PRD wording. Code wins.
+- [ ] Surface the error contract in `README.md`'s `update_wellness` bullet (one short clause) — this is interim until TP-052 puts it on the website.
+- [ ] If TP-051 has already landed and the generator's `ToolDescriptor` lacks an `errors` field needed to render this on the website, file an amendment under `taskplane-tasks/TP-051-tool-catalog-generator/PROMPT.md` (append-only under "## Amendments").
+
+### Step 5: CHANGELOG + verification
+
+- [ ] `CHANGELOG.md` `[Unreleased]` entries:
+  - Conflict A: "Changed — Analyzer family deferred to vNext; PRD updated." (or "Added — v0.6 Analyzers roadmap phase").
+  - Conflict B: "Fixed — `get_planning_parameters` ROADMAP contradiction; entry now matches registry."
+  - Conflict C: "Changed — `update_wellness` error contract surfaced in README; PRD wording aligned to code."
+- [ ] `make build`, `make test`, `make lint` — these should all still pass; if Step 4 touched `internal/tools/update_wellness.go`, ensure tests still cover the error literal.
+- [ ] `git grep -n 'analyze_\|compute_\|get_fitness_projection' README.md docs/prd ROADMAP.md` — confirm no stale references survive Conflict A's resolution.
+- [ ] `git grep -n 'get_planning_parameters' ROADMAP.md README.md` — confirm exactly one consistent statement remains in each.
+
+## Acceptance Criteria
+
+- Conflict A resolved with a documented decision: PRD reflects whether the analyzer family is deferred or scheduled, and that decision matches reality.
+- Conflict B resolved: `ROADMAP.md` no longer contradicts itself for `get_planning_parameters`, and `README.md` is consistent.
+- Conflict C resolved: `update_wellness` error contract appears in the README, matches the code's actual error literal, and the PRD wording is aligned to code.
+- `CHANGELOG.md` `[Unreleased]` records each fix.
+- `STATUS.md` documents the verification of each conflict against the current tree, the decision made for Conflict A, and the resolution for B and C.
+- All existing tests pass.
+
+## Do NOT
+
+- Do not implement the analyzer family.
+- Do not change `update_wellness`'s actual behaviour or error literal to make the docs convenient. If docs are wrong, fix docs.
+- Do not slim the README in this task — TP-054 owns that. Make minimal edits only to fix the three conflicts.
+- Do not migrate any content to the website here — TP-052 owns that.
+- Do not retag releases or amend prior CHANGELOG sections — only `[Unreleased]`.
+- Do not add emojis (per CLAUDE.md).
+
+## Documentation
+
+Must update:
+
+- `STATUS.md` — per-conflict verification, decision rationale (esp. Conflict A), grep outputs.
+- `CHANGELOG.md` `[Unreleased]`.
+
+## Git Commit Convention
+
+Commit at step boundaries with messages prefixed by `TP-055`, e.g., `TP-055 defer analyzer family in PRD`.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-055-reconcile-doc-conflicts/STATUS.md
+++ b/taskplane-tasks/TP-055-reconcile-doc-conflicts/STATUS.md
@@ -1,0 +1,31 @@
+# TP-055-reconcile-doc-conflicts — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** S
+
+---
+
+### Step 1: Re-verify all three conflicts
+
+**Status:** ⏳ Pending
+
+### Step 2: Resolve Conflict A (analyzer family)
+
+**Status:** ⏳ Pending
+
+### Step 3: Resolve Conflict B (`get_planning_parameters`)
+
+**Status:** ⏳ Pending
+
+### Step 4: Resolve Conflict C (`update_wellness` error contract)
+
+**Status:** ⏳ Pending
+
+### Step 5: CHANGELOG + verification
+
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-056-events-retry-body-close/PROMPT.md
+++ b/taskplane-tasks/TP-056-events-retry-body-close/PROMPT.md
@@ -1,0 +1,86 @@
+# TP-056 — Close response body inside `events.go` retry loop (audit Critical)
+
+## Mission
+
+`internal/intervals/events.go:239` places `defer resp.Body.Close()` inside the `for attempt := 1; ; attempt++` retry loop. Because `defer` schedules execution at function return — not loop-iteration end — every non-final iteration leaks an open body until the function eventually returns. On a hot retry path (5xx storm, network blip) this accumulates file descriptors and TCP connections.
+
+Compare with the correct pattern at `internal/intervals/client.go:236-243`, which closes the body inline (drain + close) before continuing the loop.
+
+Fix: replace the in-loop `defer` with explicit drain (`io.Copy(io.Discard, resp.Body)`) + `resp.Body.Close()` at the end of each non-success iteration; keep `defer` only outside the loop or on the terminal success branch.
+
+This was identified in the 2026-05-16 Go audit follow-up as the single Critical finding.
+
+PRD anchors: §7.4 reliability.
+CLAUDE.md hard rules: "Always close response bodies."
+
+Complexity: Blast radius 1 (single file, tightly scoped), Pattern novelty 1, Security 2 (resource leak), Reversibility 1 = 5 → Review Level 1. Size: XS.
+
+## Dependencies
+
+- None. Coordinate loosely with **TP-045** (which hardens the analogous loop in `client.go`) — if TP-045 lands first, mirror its exact close pattern here for consistency.
+
+## Context to Read First
+
+- `CLAUDE.md` — HTTP / resource-handling rules.
+- `internal/intervals/events.go:200-280` — the offending retry loop.
+- `internal/intervals/client.go:200-260` — the correct inline-close pattern to mirror.
+- `internal/intervals/events_test.go` — existing retry tests to verify nothing regresses.
+
+## File Scope
+
+- `internal/intervals/events.go` — fix the defer placement.
+- `internal/intervals/events_test.go` — add a regression test that retries 3+ times and asserts no body leak (e.g., count `Body.Close()` calls on a test `io.ReadCloser`).
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- Wider refactor of the retry loop (covered by TP-045 for the sibling file; do not generalize here).
+- Touching retry policy, jitter, or status-decision logic.
+- Renaming or moving the function.
+
+## Steps
+
+### Step 1: Reproduce the leak in a test
+
+- [ ] Add a test using an `httptest.Server` that returns 503 three times then 200. Wrap the response body in a counting `io.ReadCloser` that records `Close()` calls. Assert the count equals the number of attempts.
+- [ ] Confirm the test fails on `main`.
+
+### Step 2: Fix
+
+- [ ] Replace in-loop `defer resp.Body.Close()` with explicit drain + close on the retry branch; keep a single `defer` after the loop on the success path (or close-and-return inline).
+- [ ] Mirror the exact pattern from `internal/intervals/client.go:236-243`.
+- [ ] `make build` / `test` / `test-race` / `lint`.
+- [ ] Commit: `TP-056 close response body inside events retry loop`.
+
+### Step 3: Verify
+
+- [ ] New test passes.
+- [ ] `make test-race` clean.
+- [ ] `grep -n "defer resp.Body.Close" internal/intervals/` shows no `defer` inside any retry loop.
+
+## Acceptance Criteria
+
+- No `defer resp.Body.Close()` remains inside any `for attempt := …` loop in `internal/intervals/`.
+- Regression test asserts `Body.Close()` is called once per attempt.
+- All `make` checks pass.
+- No user-visible behaviour change.
+
+## Do NOT
+
+- Do not refactor the surrounding retry logic; that's TP-045 + TP-057.
+- Do not change retry counts, backoff, or status-decision rules.
+- Do not introduce `io.LimitReader` here (that's TP-045's scope for the other client method).
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Fixed".
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-056`. Example: `TP-056 close response body inside events retry loop`.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-056-events-retry-body-close/STATUS.md
+++ b/taskplane-tasks/TP-056-events-retry-body-close/STATUS.md
@@ -1,0 +1,20 @@
+# TP-056-events-retry-body-close — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** XS
+
+---
+
+### Step 1: Reproduce the leak in a test
+**Status:** ⏳ Pending
+
+### Step 2: Fix
+**Status:** ⏳ Pending
+
+### Step 3: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-057-intervals-retry-ctx-and-dedup/PROMPT.md
+++ b/taskplane-tasks/TP-057-intervals-retry-ctx-and-dedup/PROMPT.md
@@ -1,0 +1,95 @@
+# TP-057 — `ctx` first on `shouldRetryWrite` + consolidate retry-decision logic (audit High)
+
+## Mission
+
+The 2026-05-16 Go audit flagged two related issues in `internal/intervals/`:
+
+1. **`ctx` is not the first argument** in `internal/intervals/events.go:247`
+   `func (c *Client) shouldRetryWrite(method string, ctx context.Context, attempt int) bool` — violates Go convention and CLAUDE.md ("every function that does I/O or blocks takes `ctx context.Context` as the first argument").
+
+2. **Duplicated retry-decision logic** across `internal/intervals/client.go` and `internal/intervals/events.go`: `shouldRetry`, `shouldRetryTransport`, `shouldRetryStatus`, `shouldRetryWrite`, `shouldRetryWriteStatus`. Five near-identical helpers reading the same fields. Collapse into a single method on `*Client` that takes `(ctx, method, resp, err, attempt)` and returns `(retry bool, wait time.Duration)`.
+
+Goal: one retry-decision method, `ctx`-first, with table-driven tests covering: idempotent GET vs non-idempotent POST/PATCH/DELETE, transport errors, 408/425/429/5xx status set, `Retry-After` honouring, attempt cap.
+
+PRD anchors: §7.4 reliability.
+CLAUDE.md hard rules: `ctx` first; one obvious place for each decision; sentinel errors for stable contract points.
+
+Complexity: Blast radius 2 (touches every retry call site in the intervals package), Pattern novelty 1, Security 1, Reversibility 1 = 5 → Review Level 1. Size: S.
+
+## Dependencies
+
+- **TP-045** — coordinate. TP-045 splits `doJSONQuery` retry/transport/status concerns; this task takes the cleaned-up pieces and folds them under a single decision method. If TP-045 lands first, build on its primitives. If this lands first, leave breadcrumbs for TP-045 to pick up.
+- **TP-056** — soft. Both touch `events.go`; sequence after TP-056 to keep the diff readable.
+
+## Context to Read First
+
+- `CLAUDE.md` — Go conventions section on `ctx` argument position.
+- `internal/intervals/client.go:280-340` — `shouldRetry`, `shouldRetryTransport`, `shouldRetryStatus`, jitter helper.
+- `internal/intervals/events.go:240-280` — `shouldRetryWrite`, `shouldRetryWriteStatus`.
+- `internal/intervals/retry_test.go` (if present) — existing coverage.
+
+## File Scope
+
+- `internal/intervals/client.go` — define the consolidated `decideRetry(ctx, method, resp, err, attempt)`; delete or thin the four helpers.
+- `internal/intervals/events.go` — delete `shouldRetryWrite`/`shouldRetryWriteStatus`; route through the consolidated method.
+- `internal/intervals/retry_test.go` (new or extended) — table-driven coverage.
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- Jitter generator (covered by TP-058).
+- Body-close fix (covered by TP-056).
+- `LimitReader` / response-size hardening (covered by TP-045).
+- Changing retry counts, backoff base, or status-code set without explicit justification in `STATUS.md`.
+
+## Steps
+
+### Step 1: Capture current behaviour in a table-driven test
+- [ ] Enumerate every `(method, status, err, attempt)` combination currently handled by the five helpers.
+- [ ] Write a table that calls each existing helper and locks in the current truth table.
+- [ ] Test must pass against `main` before refactoring.
+
+### Step 2: Introduce the consolidated method
+- [ ] Add `(c *Client) decideRetry(ctx context.Context, method string, resp *http.Response, err error, attempt int) (retry bool, wait time.Duration)` in `client.go`.
+- [ ] Method must respect `RetryConfig`, `Retry-After`, idempotency by HTTP method, and `ctx.Done()`.
+- [ ] `ctx` must be the first argument everywhere it appears.
+
+### Step 3: Route all call sites through the new method
+- [ ] Replace `shouldRetry*` call sites in `client.go` and `events.go`.
+- [ ] Delete the now-unused helpers.
+- [ ] Run the table-driven test from Step 1 — must still pass with the consolidated method.
+- [ ] `make build` / `test` / `test-race` / `lint`.
+- [ ] Commit: `TP-057 consolidate intervals retry decision into one method`.
+
+### Step 4: Verify
+- [ ] `grep -n "shouldRetry" internal/intervals/` shows only the consolidated method (or zero hits if renamed).
+- [ ] `grep -n "ctx context.Context" internal/intervals/events.go` shows `ctx` always first.
+- [ ] `make test-race` clean.
+
+## Acceptance Criteria
+
+- One retry-decision method (`decideRetry` or similar) replaces the five `shouldRetry*` helpers.
+- `ctx context.Context` is the first parameter on every function that takes it in `internal/intervals/`.
+- Behaviour is byte-identical on the truth table (locked-in by Step 1 test).
+- `make` checks all pass.
+- No public API change to `*Client` consumers.
+
+## Do NOT
+
+- Do not change retry policy (counts, base backoff, status-code set, idempotency rules) without an explicit `STATUS.md` note and reviewer sign-off.
+- Do not absorb jitter logic here — TP-058 owns that.
+- Do not generalize beyond the intervals package; this is not the time for a generic `httpretry` extraction.
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Changed".
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-057`.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-057-intervals-retry-ctx-and-dedup/STATUS.md
+++ b/taskplane-tasks/TP-057-intervals-retry-ctx-and-dedup/STATUS.md
@@ -1,0 +1,23 @@
+# TP-057-intervals-retry-ctx-and-dedup — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** S
+
+---
+
+### Step 1: Capture current behaviour in a table-driven test
+**Status:** ⏳ Pending
+
+### Step 2: Introduce the consolidated method
+**Status:** ⏳ Pending
+
+### Step 3: Route all call sites through the new method
+**Status:** ⏳ Pending
+
+### Step 4: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-058-intervals-retry-jitter-rand/PROMPT.md
+++ b/taskplane-tasks/TP-058-intervals-retry-jitter-rand/PROMPT.md
@@ -1,0 +1,87 @@
+# TP-058 — Non-deterministic retry jitter using `math/rand/v2` (audit High)
+
+## Mission
+
+`internal/intervals/client.go:317` computes jitter as
+
+```go
+offset := time.Now().UnixNano()%(2*span+1) - span
+```
+
+This is deterministic per nanosecond. Multiple goroutines retrying within the same nanosecond (likely on a 429 burst) get correlated offsets, defeating the entire point of jitter (de-correlating retries to avoid thundering-herd).
+
+Fix: use `math/rand/v2` with a package-local `*rand.Rand` seeded once. Generate `rand.Int64N(2*span+1) - span` per call. `math/rand/v2` is safe for concurrent use as of Go 1.22.
+
+Audit ref: 2026-05-16 Go audit, "High" severity.
+
+PRD anchors: §7.4 reliability (no thundering herd on rate-limit storms).
+
+Complexity: Blast radius 1, Pattern novelty 1, Security 2 (defends against rate-limit feedback loops), Reversibility 1 = 5 → Review Level 1. Size: XS.
+
+## Dependencies
+
+- **TP-045** — soft. Both touch the retry helpers. If TP-045's `WithDefaults` constructor lands first, route default-jitter configuration through it. Otherwise, keep this isolated to the jitter generator only.
+- **TP-057** — sequence after TP-057 so the jitter generator sits cleanly under the consolidated `decideRetry`.
+
+## Context to Read First
+
+- `internal/intervals/client.go:300-340` — the current jitter helper.
+- `internal/intervals/client.go:48-65` — `WithDefaults()` / `RetryConfig` (related, but not changed here).
+- Go stdlib docs for `math/rand/v2` — concurrency safety, `Int64N`.
+
+## File Scope
+
+- `internal/intervals/client.go` — replace the deterministic jitter expression with a `*rand.Rand`-backed generator. Seed once at package init using `rand.NewPCG(uint64(time.Now().UnixNano()), uint64(os.Getpid()))` (or equivalent).
+- `internal/intervals/client_test.go` — add a statistical test: 1000 jitter samples must produce ≥ 90% unique values within the span.
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- Changing the jitter span / formula. Same span, just a real RNG.
+- Renaming `RetryConfig` fields.
+- The jitter-default-only-when-all-fields-zero quirk (covered by TP-045's `WithDefaults`).
+
+## Steps
+
+### Step 1: Statistical test
+- [ ] Add a test that calls the jitter helper 1000 times and asserts uniqueness ≥ 900.
+- [ ] Confirm the test fails on `main` (current deterministic helper produces too many collisions when called in tight loop).
+
+### Step 2: Switch to `math/rand/v2`
+- [ ] Replace the `time.Now().UnixNano()%...` expression with `pkgRand.Int64N(2*span+1) - span`.
+- [ ] Initialize `pkgRand` once at package level using a `sync.Once` or `var` init.
+- [ ] `math/rand/v2`'s top-level functions are already concurrency-safe; using them directly is also acceptable and simpler. Prefer the top-level form unless deterministic seeding is needed for tests.
+
+### Step 3: Verify
+- [ ] New statistical test passes.
+- [ ] `make build` / `test` / `test-race` / `lint`.
+- [ ] No new `math/rand` (v1) import anywhere; only `math/rand/v2`.
+- [ ] Commit: `TP-058 use math/rand/v2 for retry jitter`.
+
+## Acceptance Criteria
+
+- Jitter helper uses `math/rand/v2`.
+- No `time.Now()` is the only entropy source for jitter.
+- Statistical test gates against regressions.
+- `make` checks pass.
+- Go module requires Go 1.22+ (verify `go.mod`; if not, bump it).
+
+## Do NOT
+
+- Do not import `math/rand` (v1).
+- Do not change the jitter span or the backoff base.
+- Do not introduce a third-party RNG library.
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Changed".
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-058`.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-058-intervals-retry-jitter-rand/STATUS.md
+++ b/taskplane-tasks/TP-058-intervals-retry-jitter-rand/STATUS.md
@@ -1,0 +1,20 @@
+# TP-058-intervals-retry-jitter-rand — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** XS
+
+---
+
+### Step 1: Statistical test
+**Status:** ⏳ Pending
+
+### Step 2: Switch to `math/rand/v2`
+**Status:** ⏳ Pending
+
+### Step 3: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-059-workout-training-typed-bodies/PROMPT.md
+++ b/taskplane-tasks/TP-059-workout-training-typed-bodies/PROMPT.md
@@ -1,0 +1,92 @@
+# TP-059 — Replace `map[string]any` with typed structs in workout/training bodies (audit High)
+
+## Mission
+
+CLAUDE.md mandates typed structs over `map[string]any`. The 2026-05-16 audit identified three sites still using untyped maps for request/response bodies and schema literals:
+
+- `internal/tools/get_workout_library.go:62-63` — `Full` / `WorkoutDocSummary` field expressed as `map[string]any`.
+- `internal/tools/get_training_plan.go:45-46` — similar.
+- `internal/intervals/workout_library.go:208` — write body assembled as `map[string]any` instead of a typed request struct.
+
+Goal: introduce typed request/response structs (e.g., `WorkoutDocSummary`, `WorkoutLibraryWriteRequest`) and switch all three sites. Use `json.RawMessage` only for genuinely opaque passthrough (e.g., when the client must forward an upstream blob unchanged via `include_full`).
+
+Schema literals (e.g., `getWorkoutLibraryInputSchema`) can remain as Go-side schema definitions for now, but the **request/response bodies** must be typed.
+
+Audit ref: 2026-05-16 Go audit, "High" severity.
+
+PRD anchors: §7.2.C tool contracts, §7.4 reliability.
+CLAUDE.md hard rules: "prefer typed structs over `map[string]any`".
+
+Complexity: Blast radius 2 (three files + their tests), Pattern novelty 1, Security 1, Reversibility 2 (struct field set is now part of the contract) = 6 → Review Level 1. Size: S.
+
+## Dependencies
+
+- **TP-048** — coordinate. TP-048 introduces `tools.DecodeStrict[T]`; once it lands, the new typed structs in this task plug into `DecodeStrict[T]` naturally. If TP-048 lands first, use it. If this lands first, leave a TODO referencing TP-048 at each decode site.
+- **TP-019** (workout_doc serializer) — context only; the typed `WorkoutDocSummary` here must round-trip with the serializer's types.
+
+## Context to Read First
+
+- `CLAUDE.md` — Go conventions on JSON / typed structs.
+- `internal/tools/get_workout_library.go` — full file.
+- `internal/tools/get_training_plan.go` — full file.
+- `internal/intervals/workout_library.go` — focus on the write helpers around line 208.
+- `internal/workoutdoc/parse.go`, `internal/workoutdoc/serialize.go` — existing typed model for workout DSL.
+- Their `_test.go` files — locked-in fixtures.
+
+## File Scope
+
+- `internal/tools/get_workout_library.go` — replace the `map[string]any` field with a typed struct; update tests.
+- `internal/tools/get_training_plan.go` — same.
+- `internal/intervals/workout_library.go` — typed request body for the write path.
+- New file `internal/intervals/workout_library_types.go` (or inline in `workout_library.go`) — the new request/response structs.
+- Their test files.
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- Tool schemas (the JSON Schema literals can stay as-is for this task).
+- Other tools using `map[string]any` legitimately for opaque passthrough.
+- The schema literal for `getWorkoutLibraryInputSchema` itself (separate concern; flag in `CONTEXT.md` Technical Debt if it bothers you).
+
+## Steps
+
+### Step 1: Define the typed structs
+- [ ] Decide where each struct lives (tools package vs intervals package). Prefer intervals package for request/response shared with the HTTP layer.
+- [ ] Use `json:"…,omitempty"` consistently; reuse types from `internal/workoutdoc` where applicable.
+
+### Step 2: Swap request/response bodies
+- [ ] Replace each `map[string]any` body with the typed struct.
+- [ ] Update tests; verify golden fixtures decode/encode byte-identical (use `cmp.Diff` if needed).
+- [ ] `make build` / `test` / `test-race` / `lint`.
+
+### Step 3: Verify
+- [ ] `grep -n "map\[string\]any" internal/tools/get_workout_library.go internal/tools/get_training_plan.go internal/intervals/workout_library.go` — zero hits for request/response bodies. (Schema literals exempt.)
+- [ ] All `make` checks pass.
+- [ ] Commit: `TP-059 use typed structs for workout & training bodies`.
+
+## Acceptance Criteria
+
+- No `map[string]any` in request/response bodies in the three cited files.
+- New types are unexported unless they need to be shared across packages.
+- Round-trip tests prove the wire shape is unchanged.
+- `make` checks pass.
+
+## Do NOT
+
+- Do not rename existing fields or change wire JSON keys.
+- Do not absorb the schema literals into typed structs in this task — schema generation is a separate concern.
+- Do not introduce a third-party schema/generator library.
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Changed".
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-059`.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-059-workout-training-typed-bodies/STATUS.md
+++ b/taskplane-tasks/TP-059-workout-training-typed-bodies/STATUS.md
@@ -1,0 +1,20 @@
+# TP-059-workout-training-typed-bodies — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** S
+
+---
+
+### Step 1: Define the typed structs
+**Status:** ⏳ Pending
+
+### Step 2: Swap request/response bodies
+**Status:** ⏳ Pending
+
+### Step 3: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-060-mcp-server-channel-and-recover/PROMPT.md
+++ b/taskplane-tasks/TP-060-mcp-server-channel-and-recover/PROMPT.md
@@ -1,0 +1,84 @@
+# TP-060 — Buffer MCP close channel + wrap recovered panics with `%w` (audit Medium)
+
+## Mission
+
+Two small but real defects in `internal/mcp/server.go`:
+
+1. **Unbuffered close channel** at `internal/mcp/server.go:165-173`. `closed := make(chan error)` is unbuffered. The current control flow happens to work because the goroutine always sends, but a future early-return inside the goroutine — or a panic that bypasses the send — would hang the parent on `<-closed`. Make it `make(chan error, 1)` defensively.
+
+2. **`withPanicRecovery` uses `%v`, not `%w`** at `internal/mcp/server.go:298-305` (introduced by TP-049). Recovered panics are converted to `fmt.Errorf("%s: %v", name, r)` — but if `r` is itself an `error`, the original is unwrappable from the recovered side. Also: no `slog` log + `debug.Stack()` capture, so on-call has no way to see what panicked. Fix: if `r` is an `error`, wrap with `%w`; either way log a `slog.Error` with `debug.Stack()` (info only, not returned to the LLM).
+
+Audit ref: 2026-05-16 Go audit, "Medium" severity.
+
+PRD anchors: §7.4 reliability; errors back to LLM "short, actionable, free of internal stack traces" — stack stays in logs only.
+
+CLAUDE.md hard rules: no `panic` outside `main`; wrap with `%w`.
+
+Complexity: Blast radius 1, Pattern novelty 1, Security 1, Reversibility 1 = 4 → Review Level 1. Size: XS.
+
+## Dependencies
+
+- **TP-049** — sequence after. TP-049 already extracted `withPanicRecovery` into a helper; this task hardens its body. If TP-049 has merged, just edit the helper.
+- **TP-063** — soft. TP-063 splits `mcp/server.go`; if TP-063 lands first, edit the new location of `withPanicRecovery` (likely `mcp/recover.go`).
+
+## Context to Read First
+
+- `internal/mcp/server.go:160-180` — the close channel pattern.
+- `internal/mcp/server.go:290-310` — the `withPanicRecovery` helper.
+- `runtime/debug.Stack` docs.
+- CLAUDE.md "Logging" section — `log/slog` rules, never log API keys.
+
+## File Scope
+
+- `internal/mcp/server.go` (or wherever TP-063 has moved these) — the two fixes only.
+- `internal/mcp/server_test.go` — add (a) a test that the close-path doesn't hang when the inner goroutine returns without sending, (b) a test that a panicking handler produces a wrapped error AND a logged stack.
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- Wider transport refactor (TP-063).
+- Changing the recover scope (still only at the SDK protocol boundary).
+- Capturing stacks for non-panic errors.
+
+## Steps
+
+### Step 1: Buffer the close channel
+- [ ] Change `make(chan error)` to `make(chan error, 1)` at the cited line.
+- [ ] Add a test that the parent does not block when the inner goroutine returns early.
+
+### Step 2: Harden `withPanicRecovery`
+- [ ] If `r` is `error`: `err = fmt.Errorf("%s: %w", name, rErr)`. Otherwise: `err = fmt.Errorf("%s: %v", name, r)` (keep `%v` only for non-error values).
+- [ ] Log via `slog.Default().Error("panic recovered", "scope", name, "stack", string(debug.Stack()))`. **Never** log raw API keys or athlete IDs; log only the helper's `name` argument plus the stack.
+- [ ] Add a test that asserts: (a) returned error wraps the panic when it was an error, (b) `debug.Stack()` is captured in the log (use a test handler).
+
+### Step 3: Verify
+- [ ] `make build` / `test` / `test-race` / `lint`.
+- [ ] Commit: `TP-060 buffer mcp close channel and wrap recovered panics`.
+
+## Acceptance Criteria
+
+- `closed := make(chan error, 1)` (or equivalent buffered pattern).
+- `withPanicRecovery` returns wrapped errors when the panic value was an error.
+- Stack is captured into structured logs at `slog.Error`.
+- No API key, token, or athlete ID is ever logged.
+- All `make` checks pass.
+
+## Do NOT
+
+- Do not return the stack to the LLM — keep error messages short.
+- Do not widen recover scope; still only at the SDK protocol boundary.
+- Do not introduce a panic-handler library.
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Fixed" and "Changed".
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-060`.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-060-mcp-server-channel-and-recover/STATUS.md
+++ b/taskplane-tasks/TP-060-mcp-server-channel-and-recover/STATUS.md
@@ -1,0 +1,20 @@
+# TP-060-mcp-server-channel-and-recover — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** XS
+
+---
+
+### Step 1: Buffer the close channel
+**Status:** ⏳ Pending
+
+### Step 2: Harden `withPanicRecovery`
+**Status:** ⏳ Pending
+
+### Step 3: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-061-tools-validation-sentinel/PROMPT.md
+++ b/taskplane-tasks/TP-061-tools-validation-sentinel/PROMPT.md
@@ -1,0 +1,98 @@
+# TP-061 — Introduce `ErrInvalidInput` sentinel and route validation errors through it (audit Medium)
+
+## Mission
+
+Several tool handlers use bare `fmt.Errorf("…")` for input-validation failures. Examples flagged by the 2026-05-16 audit:
+
+- `internal/tools/get_activities.go:244`
+- `internal/tools/delete_events_by_date_range.go:120`
+- `internal/tools/apply_training_plan.go:160`
+- `internal/tools/update_wellness.go:222, 232`
+
+These are correct messages but unpairable with `errors.Is` — downstream callers and tests resort to string matching, which CLAUDE.md explicitly forbids ("Use `errors.Is` / `errors.As` at call sites; never `err.Error() == "..."`").
+
+Fix: introduce a single `tools.ErrInvalidInput` (or `tools.UserError` already exists — confirm and reuse) sentinel. Validation errors wrap it: `fmt.Errorf("%w: end_date must be after start_date", tools.ErrInvalidInput)`. Then:
+
+- Registry/handler error mapping can `errors.Is(err, tools.ErrInvalidInput)` to format a short LLM-facing error.
+- Tests can assert validation paths without string matching.
+
+Audit ref: 2026-05-16 Go audit, "Medium" severity.
+
+PRD anchors: §7.4 reliability; "errors back to the LLM must be short, actionable, free of internal stack traces."
+CLAUDE.md hard rules: "Sentinel errors for stable contract points; use `errors.Is`/`errors.As`."
+
+Complexity: Blast radius 2 (touches ~5 tool files plus registry error mapper), Pattern novelty 1, Security 1, Reversibility 1 = 5 → Review Level 1. Size: S.
+
+## Dependencies
+
+- **TP-042** — soft. TP-042 collapses registry error mapping; once it lands, plug the sentinel into the new mapper. If this lands first, leave a TODO at the mapper for TP-042 to pick up.
+- **TP-048** — `tools.UserError` may already serve this purpose. **Read TP-048 PROMPT before deciding** whether to add a new sentinel or extend `UserError`. Prefer extending the existing type.
+
+## Context to Read First
+
+- `CLAUDE.md` — Errors section.
+- `internal/tools/registry.go:269-397` — existing `UserError` type and where errors flow back to the protocol.
+- The five cited validation sites.
+- Tests for any of the above — to understand current assertion style.
+
+## File Scope
+
+- New (or extended): `internal/tools/errors.go` — declare `ErrInvalidInput` (or extend `UserError` with an `IsInvalidInput()` accessor) and `func Wrap(err error) UserError` if needed.
+- The five validation sites — switch to wrap the sentinel.
+- `internal/tools/registry.go` (or wherever errors are mapped to LLM-facing strings) — branch on `errors.Is(err, ErrInvalidInput)`.
+- Affected tool tests — replace any string-match assertions with `errors.Is`.
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- Internal infra/transport errors (don't introduce sentinels for those here).
+- Wholesale sweep of every `fmt.Errorf` in the tools package — only validation errors flagged by the audit.
+- Renaming `UserError`.
+
+## Steps
+
+### Step 1: Decide on the sentinel home
+- [ ] Read TP-048's plan for `UserError`. Decide: new `var ErrInvalidInput = errors.New("invalid input")` vs an `IsInvalidInput()` method on `UserError`. Record the decision in `STATUS.md`.
+
+### Step 2: Wire the sentinel into the five sites
+- [ ] At each site, change `fmt.Errorf("end_date must be after start_date")` to `fmt.Errorf("%w: end_date must be after start_date", tools.ErrInvalidInput)` (or the equivalent `UserError` constructor).
+- [ ] Update or add tests at each site to assert with `errors.Is(err, tools.ErrInvalidInput)`.
+
+### Step 3: Route through the LLM-facing mapper
+- [ ] At the registry/handler boundary, return a short LLM-facing string for `ErrInvalidInput`; do not include the wrapped error chain in the LLM-visible message.
+- [ ] Log the full wrapped error via `slog.Warn` for the operator (without API keys / IDs).
+
+### Step 4: Verify
+- [ ] `grep -n 'fmt.Errorf("[^%]' internal/tools/` for the five sites — each must now use `%w`.
+- [ ] `grep -rn 'err.Error() ==' internal/tools/` — zero hits.
+- [ ] `make build` / `test` / `test-race` / `lint`.
+- [ ] Commit: `TP-061 introduce ErrInvalidInput sentinel for tool validation`.
+
+## Acceptance Criteria
+
+- A single sentinel (`tools.ErrInvalidInput` or equivalent `UserError` capability) covers validation errors.
+- The five cited sites are migrated.
+- LLM-facing message stays short; full chain is logged only.
+- `errors.Is` is the only assertion style in affected tests.
+- All `make` checks pass.
+
+## Do NOT
+
+- Do not introduce a sentinel per error message — one is enough.
+- Do not change wire/JSON structure of error responses.
+- Do not expand scope to non-tools packages.
+- Do not let the wrapped error chain leak into the LLM-facing string.
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Changed".
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-061`.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-061-tools-validation-sentinel/STATUS.md
+++ b/taskplane-tasks/TP-061-tools-validation-sentinel/STATUS.md
@@ -1,0 +1,23 @@
+# TP-061-tools-validation-sentinel — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** S
+
+---
+
+### Step 1: Decide on the sentinel home
+**Status:** ⏳ Pending
+
+### Step 2: Wire the sentinel into the five sites
+**Status:** ⏳ Pending
+
+### Step 3: Route through the LLM-facing mapper
+**Status:** ⏳ Pending
+
+### Step 4: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-062-config-slog-logvaluer/PROMPT.md
+++ b/taskplane-tasks/TP-062-config-slog-logvaluer/PROMPT.md
@@ -1,0 +1,77 @@
+# TP-062 — `Config` implements `slog.LogValuer` (audit Low)
+
+## Mission
+
+`internal/config/config.go:340` defines `Config.String()` that produces a single redacted line. The 2026-05-16 audit notes this is hard to consume in structured logs — operators have to parse a string out of `slog` attributes.
+
+Fix: implement `LogValue() slog.Value` returning a `slog.Group` with explicit attrs (`api_base_url`, `default_athlete_id`, `http_bind`, `coach_athletes_count`, `delete_mode`, `toolset`). Continue to redact `api_key`. Keep `String()` for human/error contexts (config diagnostics CLI), but make `slog` consumers automatically get structured attrs.
+
+Audit ref: 2026-05-16 Go audit, "Low" severity.
+
+PRD anchors: §7.4 reliability.
+CLAUDE.md hard rules: structured logging with `log/slog`; never log API keys.
+
+Complexity: Blast radius 1, Pattern novelty 1, Security 2 (redaction must hold), Reversibility 1 = 5 → Review Level 1. Size: XS.
+
+## Dependencies
+
+- **TP-066** — soft. TP-066 splits `config.go` into multiple files; if it lands first, place `LogValue` in the file owning `String()` (likely `redaction.go` or `config.go`).
+
+## Context to Read First
+
+- `internal/config/config.go:320-350` — current `String()` and redaction.
+- Go stdlib `log/slog` docs: `LogValuer` interface, `slog.Group`, `slog.Value`.
+- CLAUDE.md "Logging" section.
+
+## File Scope
+
+- `internal/config/config.go` (or wherever `String()` lives post-TP-066) — add `LogValue() slog.Value`.
+- `internal/config/config_test.go` — table-driven test asserting (a) `LogValue` returns a Group, (b) `api_key` is never present, (c) all other public fields are present, (d) `slog.Default().Info("config", "cfg", cfg)` produces the expected attrs (use a test handler).
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- Removing `String()`; keep it for non-`slog` contexts.
+- Changing redaction policy.
+- Restructuring `Config` exported fields.
+
+## Steps
+
+### Step 1: Implement `LogValue`
+- [ ] Add `func (c Config) LogValue() slog.Value` returning a `slog.GroupValue(slog.Group("config", attrs...).Value)` — never include `api_key`.
+- [ ] If any nested struct (e.g., `CoachAthletes`) is included, also implement `LogValue` for it or summarize as a count.
+
+### Step 2: Test
+- [ ] Use `slog.New(slog.NewJSONHandler(&buf, nil))` and assert the produced JSON has the expected keys and never `api_key`.
+- [ ] Add a fuzzy / negative test: set `Config.APIKey = "secret-xxxxx"` and assert `strings.Contains(buf.String(), "secret")` is false.
+
+### Step 3: Verify
+- [ ] `make build` / `test` / `test-race` / `lint`.
+- [ ] Commit: `TP-062 config: implement slog.LogValuer with redaction`.
+
+## Acceptance Criteria
+
+- `Config` implements `slog.LogValuer`.
+- `api_key` is never present in the structured output.
+- Test asserts redaction holds.
+- All `make` checks pass.
+
+## Do NOT
+
+- Do not include the API key (or any prefix/suffix of it) in attrs.
+- Do not change the human-readable `String()` output.
+- Do not log athlete IDs in a way that's hard to scrub (use a redacted form if needed).
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Changed".
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-062`.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-062-config-slog-logvaluer/STATUS.md
+++ b/taskplane-tasks/TP-062-config-slog-logvaluer/STATUS.md
@@ -1,0 +1,20 @@
+# TP-062-config-slog-logvaluer — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** XS
+
+---
+
+### Step 1: Implement `LogValue`
+**Status:** ⏳ Pending
+
+### Step 2: Test
+**Status:** ⏳ Pending
+
+### Step 3: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-063-split-get-fitness-one-tool-per-file/PROMPT.md
+++ b/taskplane-tasks/TP-063-split-get-fitness-one-tool-per-file/PROMPT.md
@@ -1,0 +1,96 @@
+# TP-063 — Split `internal/tools/get_fitness.go` into one-file-per-tool (audit God-module, CLAUDE.md rule violation)
+
+## Mission
+
+`internal/tools/get_fitness.go` (673 LOC) packs **four distinct tools** — `get_fitness`, `get_best_efforts`, `get_power_curves`, `get_training_summary` — into a single file. This is a direct violation of CLAUDE.md line 50:
+
+> "Add new tools as `internal/tools/<tool_name>.go` with a matching `_test.go`."
+
+Goal: split into four tool files (`get_fitness.go`, `get_best_efforts.go`, `get_power_curves.go`, `get_training_summary.go`), with a sibling `fitness_shared.go` for genuinely shared helpers (bucketing, curve smoothing). Tests follow the same split (`get_best_efforts_test.go`, etc.).
+
+This is a mechanical refactor with **no behaviour change** — tool names, schemas, registration order, and outputs must all be byte-identical.
+
+Audit ref: 2026-05-16 Go audit, God-module section.
+
+PRD anchors: §7.2.C tool catalog (no name/schema change).
+CLAUDE.md hard rules: one file per tool.
+
+Complexity: Blast radius 2 (touches the tools package internally; no external consumers), Pattern novelty 1, Security 1, Reversibility 1 = 5 → Review Level 1. Size: S.
+
+## Dependencies
+
+- **TP-049** Step 4 — reformat long constructor lines in `get_fitness.go`. Sequence after TP-049 so reformatting and splitting don't conflict.
+- **TP-048** — soft. If `tools.DecodeStrict`/`tools.TextResult` exist, each new file should use them.
+
+## Context to Read First
+
+- `CLAUDE.md` line 50 — the rule being enforced.
+- `internal/tools/get_fitness.go` — full file.
+- `internal/tools/get_fitness_test.go` — locked-in golden tests.
+- `internal/tools/registry.go` — where the four tools are registered.
+- One or two simpler one-file-per-tool examples for the target shape (e.g., `internal/tools/get_athlete_profile.go`).
+
+## File Scope
+
+- New: `internal/tools/get_best_efforts.go`, `get_power_curves.go`, `get_training_summary.go`. Move the input/output types, schema, handler, and constructor for each tool into its own file.
+- Keep: `internal/tools/get_fitness.go` for the `get_fitness` tool only.
+- New (if needed): `internal/tools/fitness_shared.go` for helpers used by 2+ of the split files. Resist over-extraction.
+- Split tests correspondingly: `get_best_efforts_test.go`, etc.
+- No change to `internal/tools/registry.go` order or call sites — registration order is observable via the catalog.
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- Behaviour changes — schemas, defaults, outputs all byte-identical.
+- Schema rewrites; even if a schema is wonky, do not touch it here.
+- Renaming tools.
+
+## Steps
+
+### Step 1: Map the contents of `get_fitness.go`
+- [ ] Catalog every top-level decl by tool ownership; record in `STATUS.md`.
+- [ ] Identify genuinely shared helpers (used by 2+ tools).
+
+### Step 2: Split
+- [ ] Move per-tool types/schemas/handlers/constructors into their own files.
+- [ ] Move shared helpers into `fitness_shared.go` only if used by ≥ 2 of the new files. Otherwise duplicate-and-rename or inline — three similar lines is better than premature abstraction.
+- [ ] Mirror the test split.
+
+### Step 3: Verify byte-identical behaviour
+- [ ] Run the existing test suite — every test must still pass without modification (other than file moves).
+- [ ] `make build` / `test` / `test-race` / `lint`.
+- [ ] `bin/icuvisor` `list_advanced_capabilities` (or the equivalent catalog dump) — diff against pre-refactor must be empty.
+- [ ] `scripts/snapshot_tool_schemas.go` output diff must be empty.
+
+### Step 4: Wrap up
+- [ ] Commit per tool extraction (4 commits) for review clarity, prefixed `TP-063`.
+- [ ] Final commit: `TP-063 finalize get_fitness split` (the registry/shared helper cleanups, if any).
+
+## Acceptance Criteria
+
+- `internal/tools/get_fitness.go` contains only the `get_fitness` tool.
+- Three new files exist, one per remaining tool.
+- Optional `fitness_shared.go` only if used by ≥ 2 files.
+- Tool catalog, schemas, and outputs are byte-identical to pre-refactor (verified via `scripts/snapshot_tool_schemas.go`).
+- All `make` checks pass.
+
+## Do NOT
+
+- Do not change tool names, descriptions, or schemas.
+- Do not change registration order in `registry.go`.
+- Do not introduce a "fitness handler" abstraction layer to share code — keep helpers small and explicit.
+- Do not start factoring other multi-tool files in this task.
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Changed" (internal refactor; no user-visible change).
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-063`. One commit per extracted tool plus a finalize commit.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-063-split-get-fitness-one-tool-per-file/STATUS.md
+++ b/taskplane-tasks/TP-063-split-get-fitness-one-tool-per-file/STATUS.md
@@ -1,0 +1,23 @@
+# TP-063-split-get-fitness-one-tool-per-file — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** S
+
+---
+
+### Step 1: Map the contents
+**Status:** ⏳ Pending
+
+### Step 2: Split
+**Status:** ⏳ Pending
+
+### Step 3: Verify byte-identical behaviour
+**Status:** ⏳ Pending
+
+### Step 4: Wrap up
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-064-split-mcp-server-and-coach-extract/PROMPT.md
+++ b/taskplane-tasks/TP-064-split-mcp-server-and-coach-extract/PROMPT.md
@@ -1,0 +1,120 @@
+# TP-064 — Split `internal/mcp/server.go` and lift coach middleware to `internal/coach` (audit God-module + God-package)
+
+## Mission
+
+`internal/mcp/server.go` is 818 LOC and mixes:
+
+- server lifecycle (`NewServer`, `Run`, `RunStreamableHTTP`),
+- a 270-LOC `safeRegistrar` (lines ~315-605) that does tool registration AND coach-mode visibility filtering AND athlete-ID schema injection,
+- resource and prompt registrars,
+- JSON schema mutation (`schemaWithAthleteID`, `stripAthleteID`),
+- validation helpers + SDK ↔ tools type conversion,
+- and a tool handler living in transport: `coachFilteredAdvancedCapabilitiesHandler` (lines ~566-606).
+
+This couples transport ↔ authz ↔ tool shaping; any cross-cutting concern (audit, rate-limit, per-tool flag) needs edits in all three layers.
+
+Goal:
+
+1. **Split `mcp/server.go` by concern:**
+   - `mcp/transport.go` — `Run`, `RunStreamableHTTP`, `normalizeHTTPServerError`, `transportName`.
+   - `mcp/registrar_tools.go` — the `safeRegistrar` core minus coach concerns.
+   - `mcp/registrar_resources.go`, `mcp/registrar_prompts.go`.
+   - `mcp/schema.go` — `schemaWithAthleteID`, `stripAthleteID`, `validate*`, SDK type conversion.
+   - `mcp/server.go` keeps `NewServer` + the public constructor only.
+
+2. **Lift coach-mode concerns into `internal/coach`:** the existing `internal/coach` package owns selection state. Move coach-visibility filtering and `coachFilteredAdvancedCapabilitiesHandler` to live there (or to `internal/tools/list_advanced_capabilities.go`), expose a `coach.ToolFilter(ctx, registry, athleteID) []Tool` (signature TBD), and have `mcp/registrar_tools.go` call it. Transport stops importing coach internals.
+
+Audit ref: 2026-05-16 Go audit, God-module + God-package sections.
+
+PRD anchors: §7.2.G coach mode; §7.2.E catalog tiers.
+CLAUDE.md hard rules: small packages, narrow interfaces.
+
+Complexity: Blast radius 4 (touches transport, registrar, coach, tests), Pattern novelty 2 (new coach filter interface), Security 3 (coach ACL must not regress), Reversibility 2 (package surface change) = 11 → Review Level 3. Size: L.
+
+## Dependencies
+
+- **TP-042** — sequence after. TP-042 collapses registry interface-assertion sprawl; the cleaner registry surface makes this split safer.
+- **TP-060** — soft. TP-060 hardens `withPanicRecovery`; if it lands first, port the helper to its new file location (likely `mcp/recover.go`).
+- **TP-039** (coach mode) — context only; behaviour must be preserved exactly.
+
+## Context to Read First
+
+- `internal/mcp/server.go` — full file. Categorize every decl by target file.
+- `internal/coach/*.go` — current coach package structure and selection store.
+- `internal/tools/list_advanced_capabilities.go` — destination candidate for the filtered handler.
+- `docs/coach-mode.md`, `docs/threat-models/coach-mode.md` — the ACL contract that must be preserved.
+- `internal/mcp/server_test.go` — existing coverage. Identify the coach-ACL tests; they become the regression gate.
+
+## File Scope
+
+- Inside `internal/mcp/`: keep package boundary. Split into the new files listed above.
+- Inside `internal/coach/`: add `filter.go` (or similar) housing the tool-visibility filter and the advanced-capabilities handler.
+- `internal/tools/list_advanced_capabilities.go` — adjust if the handler lands here instead.
+- `internal/mcp/server_test.go` — split alongside the source split where it improves clarity.
+- Tests in `internal/coach/` — add coverage for the moved filter.
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- Changing the MCP wire protocol.
+- Changing coach ACL semantics. Same matrix, just lifted.
+- Adding new cross-cutting concerns (audit, rate-limit) — file follow-ups in `CONTEXT.md` Technical Debt.
+- Touching tool schemas / catalog metadata.
+
+## Steps
+
+### Step 1: Inventory + capture regression-gate tests
+- [ ] List every top-level decl in `mcp/server.go` and assign each to a target file. Record in `STATUS.md`.
+- [ ] Identify all coach-ACL tests across packages (probably in `mcp/server_test.go` and `internal/tools/list_advanced_capabilities_test.go`). They become the immovable gate — every one must pass after the refactor.
+
+### Step 2: Mechanical file split
+- [ ] Move decls into the new files **without changing logic**. Cross-file private helpers stay package-private.
+- [ ] Each commit moves one concern (transport, schema, etc.) — keep diffs reviewable.
+- [ ] Run all checks after each move.
+
+### Step 3: Lift coach concerns to `internal/coach`
+- [ ] Design the seam: probably `coach.ToolFilter` taking the registry catalog + selection ctx and returning the filtered catalog. Sketch in `STATUS.md` first.
+- [ ] Move `coachFilteredAdvancedCapabilitiesHandler` to its new home.
+- [ ] `mcp/registrar_tools.go` calls into `coach` instead of inlining the filter.
+- [ ] Re-run all tests; coach-ACL tests must pass unchanged.
+
+### Step 4: Verify
+- [ ] `make build` / `test` / `test-race` / `lint`.
+- [ ] `scripts/snapshot_tool_schemas.go` — diff empty.
+- [ ] Coach-mode integration tests (in TP-039's test set) — all pass.
+- [ ] No new public-API surface in `internal/mcp` beyond what existed before.
+
+## Acceptance Criteria
+
+- `internal/mcp/server.go` is < 200 LOC and holds only the constructor + package doc comment.
+- The transport/registrar/schema responsibilities live in their own files.
+- `internal/coach` owns tool-visibility filtering; `internal/mcp` no longer references coach internals beyond the seam.
+- Coach ACL behaviour is byte-identical (regression-gate tests pass unchanged).
+- All `make` checks pass.
+
+## Do NOT
+
+- Do not change MCP wire behaviour.
+- Do not change coach ACL semantics or visible tool sets.
+- Do not add new dependencies.
+- Do not collapse the file split into a single big commit — reviewers need per-concern diffs.
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Changed" (internal refactor).
+- If the coach package gains an exported `ToolFilter` API, add a short note in `docs/coach-mode.md`.
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-064`. Recommended sequence:
+1. `TP-064 split mcp transport into transport.go`
+2. `TP-064 extract mcp schema helpers`
+3. `TP-064 split mcp resource/prompt registrars`
+4. `TP-064 lift coach filter into internal/coach`
+5. `TP-064 finalize mcp/server.go to constructor only`
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-064-split-mcp-server-and-coach-extract/STATUS.md
+++ b/taskplane-tasks/TP-064-split-mcp-server-and-coach-extract/STATUS.md
@@ -1,0 +1,23 @@
+# TP-064-split-mcp-server-and-coach-extract — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 3
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** L
+
+---
+
+### Step 1: Inventory + capture regression-gate tests
+**Status:** ⏳ Pending
+
+### Step 2: Mechanical file split
+**Status:** ⏳ Pending
+
+### Step 3: Lift coach concerns to `internal/coach`
+**Status:** ⏳ Pending
+
+### Step 4: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-065-split-shaper-jsonenc/PROMPT.md
+++ b/taskplane-tasks/TP-065-split-shaper-jsonenc/PROMPT.md
@@ -1,0 +1,101 @@
+# TP-065 — Split `internal/response/shaper.go` into focused files (audit God-module)
+
+## Mission
+
+`internal/response/shaper.go` is 771 LOC and tangles three responsibilities:
+
+- (a) Hand-rolled reflection-based JSON marshaller (lines ~86-365) that partly duplicates `encoding/json`.
+- (b) JSON tree walker (`walkJSON`, lines ~387-425) — the target of TP-047's consolidation.
+- (c) MCP response shaping / meta enrichment (lines ~427-611).
+
+Even after TP-043 (remove global state) and TP-047 (consolidate walkers) land, the file remains a god module. Goal: finish the job by splitting into focused files (or a small subpackage where it pays for itself):
+
+- `internal/response/marshal.go` — `toJSONValue` / reflection-based marshaller. Consider extracting to subpackage `internal/response/jsonenc/` **only if** the marshaller survives TP-047 (TP-047 may drop the marshal round-trip entirely; in that case this step is a no-op).
+- `internal/response/walk.go` — single tree-walker primitive.
+- `internal/response/shape.go` — public shaping API surface.
+- `internal/response/meta.go` — catalog/version/scale/unit `_meta` enrichment.
+
+This is the final cleanup pass on `shaper.go`. No behaviour change.
+
+Audit ref: 2026-05-16 Go audit, God-module section.
+
+PRD anchors: §7.2.D response shaping invariants.
+CLAUDE.md hard rules: small packages, small files, one obvious concern per file.
+
+Complexity: Blast radius 3 (touches the response package's internal layout), Pattern novelty 2 (subpackage decision), Security 1, Reversibility 2 = 8 → Review Level 2. Size: M.
+
+## Dependencies
+
+- **TP-043** — must land first. TP-043 removes global mutable state; splitting before that lands risks duplicating the state-removal work.
+- **TP-047** — must land first. TP-047 consolidates walkers and may drop the marshal round-trip. The set of files needed here depends on TP-047's outcome.
+- **TP-051** (tool catalog generator) — soft. If the catalog generator references `response.SetCatalogMeta` (or similar), keep the public API stable across the split.
+
+## Context to Read First
+
+- TP-043 and TP-047 PROMPT.md + STATUS.md — understand what they leave behind.
+- `internal/response/shaper.go` — full file (post-TP-043, post-TP-047 if both have landed).
+- `internal/response/shaper_test.go` — golden tests that must keep passing.
+- Any external caller of `internal/response.*` — verify the public surface remains.
+
+## File Scope
+
+- Split `internal/response/shaper.go` into the files listed above, inside the same package.
+- Decide on `internal/response/jsonenc/` subpackage **only if** the marshaller survived TP-047 and exceeds ~200 LOC. Otherwise keep `marshal.go` in `internal/response/`.
+- No public API change. Same exported names, same signatures.
+- Test files split alongside the source split where it improves clarity.
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- New marshalling strategies (covered by TP-047).
+- Removing further globals (covered by TP-043).
+- Changing `_meta` contents or shape.
+- Changing pagination / unit / scale outputs.
+
+## Steps
+
+### Step 1: Re-baseline after TP-043 + TP-047
+- [ ] Confirm both have landed; if not, block this task.
+- [ ] Inventory every top-level decl in the post-merge `shaper.go` and assign each to a target file. Record in `STATUS.md`.
+
+### Step 2: Decide on subpackage
+- [ ] If `toJSONValue` survives TP-047 and > 200 LOC: create `internal/response/jsonenc/`. Otherwise: keep in `internal/response/marshal.go`.
+- [ ] Document the decision in `STATUS.md` with the line-count evidence.
+
+### Step 3: Mechanical split
+- [ ] Move decls into the new files without logic changes.
+- [ ] Run the full test suite after each file move.
+
+### Step 4: Verify
+- [ ] `make build` / `test` / `test-race` / `lint`.
+- [ ] `scripts/snapshot_tool_schemas.go` diff empty.
+- [ ] `wc -l internal/response/*.go` — each focused file ≤ ~300 LOC.
+
+## Acceptance Criteria
+
+- `internal/response/shaper.go` is either deleted or contains only the package doc + the public shaping entry point.
+- Marshal / walk / shape / meta concerns each have their own file (or `jsonenc/` subpackage).
+- Public API unchanged.
+- All `make` checks pass.
+- No new global state, no `init()` functions.
+
+## Do NOT
+
+- Do not start before TP-043 and TP-047 have merged.
+- Do not change `_meta` semantics or wire shape.
+- Do not introduce a third-party JSON library.
+- Do not expose new public types/functions.
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Changed" (internal refactor).
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-065`. One commit per file extraction is fine; reviewers will want diffs they can read.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-065-split-shaper-jsonenc/STATUS.md
+++ b/taskplane-tasks/TP-065-split-shaper-jsonenc/STATUS.md
@@ -1,0 +1,23 @@
+# TP-065-split-shaper-jsonenc — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open  (blocked on TP-043, TP-047)
+**Last Updated:** 2026-05-16
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** M
+
+---
+
+### Step 1: Re-baseline after TP-043 + TP-047
+**Status:** ⏳ Pending
+
+### Step 2: Decide on subpackage
+**Status:** ⏳ Pending
+
+### Step 3: Mechanical split
+**Status:** ⏳ Pending
+
+### Step 4: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-066-split-get-activities-strava-codec/PROMPT.md
+++ b/taskplane-tasks/TP-066-split-get-activities-strava-codec/PROMPT.md
@@ -1,0 +1,105 @@
+# TP-066 — Extract Strava heuristic + cursor codec from `internal/tools/get_activities.go` (audit God-module)
+
+## Mission
+
+`internal/tools/get_activities.go` is 738 LOC and (even after TP-044 lands the pagination driver refactor) still folds together:
+
+- Strava-blocked detection: `isStravaBlocked` (~lines 650-687), a 37-LOC decision tree branching on upstream markers and `N/A` field heuristics.
+- Cursor codec: opaque `next_page_token` encode/decode.
+- Unit / pace shaping helpers (`round`, `intValue`, `firstFloat`).
+- Schema literals.
+- Handler glue.
+
+Goal:
+
+1. Extract Strava detection to `internal/tools/get_activities_strava.go` with a table-driven test covering the audit's listed cases (Strava-imported marker present; `N/A` HR/cadence on power-only file; manual entries).
+2. Extract cursor codec to `internal/tools/get_activities_cursor.go` (or `internal/tools/cursor.go` if generic enough across tools — but resist generalizing unless 2+ tools share the codec today).
+3. Move row-shaping helpers to `internal/tools/get_activities_row.go`.
+
+This is a focused, behaviour-preserving split. No schema or wire change.
+
+Audit ref: 2026-05-16 Go audit, God-module section.
+
+PRD anchors: §7.2.C `get_activities`; §7.2.E pagination invariants; PRD note on Strava-imported labelling.
+CLAUDE.md hard rules: small files; one obvious concern per file; "small interface".
+
+Complexity: Blast radius 2 (tools package internal), Pattern novelty 1, Security 1, Reversibility 1 = 5 → Review Level 1. Size: S.
+
+## Dependencies
+
+- **TP-044** — must land first. TP-044 refactors the pagination driver; doing this split on top of TP-044's cleaner shape is much safer.
+- **TP-048** — soft. If `tools.DecodeStrict` / `tools.TextResult` have landed, use them.
+
+## Context to Read First
+
+- `internal/tools/get_activities.go` (post-TP-044) — full file.
+- `internal/tools/get_activities_test.go` — locked-in cases.
+- The PRD section on Strava-imported activities labelling — the contract `isStravaBlocked` defends.
+
+## File Scope
+
+- New: `internal/tools/get_activities_strava.go` — pure-function Strava detection + its table test (`get_activities_strava_test.go`).
+- New: `internal/tools/get_activities_cursor.go` — encode/decode + invariants (opacity, byte-identical round-trip) + test.
+- New (optional): `internal/tools/get_activities_row.go` — row-shaping helpers if ≥ 30 LOC.
+- Trim: `internal/tools/get_activities.go` to handler + schema + glue.
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- Changing the Strava detection rules.
+- Changing the `next_page_token` format (opaque contract; must round-trip unchanged).
+- Generalizing the cursor codec across tools.
+- Changing tool schema or output shape.
+
+## Steps
+
+### Step 1: Capture golden tests
+- [ ] Before any move, ensure there is a test that asserts the `next_page_token` format is byte-identical for at least one full page sweep. If not, add one (using a fixed seed / fixed page).
+- [ ] Same for `isStravaBlocked` — table test covering each branch.
+
+### Step 2: Extract Strava heuristic
+- [ ] Move `isStravaBlocked` + helpers to `get_activities_strava.go`. Keep package-private.
+- [ ] Move tests to `get_activities_strava_test.go`.
+- [ ] Run all checks.
+
+### Step 3: Extract cursor codec
+- [ ] Move encode/decode + token format constants to `get_activities_cursor.go`.
+- [ ] Run all checks; token must round-trip byte-identical against pre-refactor snapshot.
+
+### Step 4: Extract row helpers (if ≥ 30 LOC)
+- [ ] Move `round`, `intValue`, `firstFloat` etc. to `get_activities_row.go`.
+- [ ] If under 30 LOC, leave them in `get_activities.go` — premature abstraction is worse than the smell.
+
+### Step 5: Verify
+- [ ] `make build` / `test` / `test-race` / `lint`.
+- [ ] `scripts/snapshot_tool_schemas.go` diff empty.
+- [ ] `wc -l internal/tools/get_activities*.go` — main file ≤ ~350 LOC.
+
+## Acceptance Criteria
+
+- `isStravaBlocked` lives in its own file with a table-driven test.
+- Cursor codec lives in its own file with a round-trip test.
+- Main `get_activities.go` shrinks to handler + schema + glue (≤ ~350 LOC).
+- Wire shape and tool schema are byte-identical.
+- All `make` checks pass.
+
+## Do NOT
+
+- Do not change Strava-detection rules without an explicit `STATUS.md` note and PRD pointer.
+- Do not change `next_page_token` format. Opacity is a contract.
+- Do not generalize the cursor codec across tools in this task.
+- Do not touch unit/pace canonicalization rules.
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Changed" (internal refactor).
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-066`. One commit per extraction.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-066-split-get-activities-strava-codec/STATUS.md
+++ b/taskplane-tasks/TP-066-split-get-activities-strava-codec/STATUS.md
@@ -1,0 +1,26 @@
+# TP-066-split-get-activities-strava-codec — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open  (blocked on TP-044)
+**Last Updated:** 2026-05-16
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** S
+
+---
+
+### Step 1: Capture golden tests
+**Status:** ⏳ Pending
+
+### Step 2: Extract Strava heuristic
+**Status:** ⏳ Pending
+
+### Step 3: Extract cursor codec
+**Status:** ⏳ Pending
+
+### Step 4: Extract row helpers
+**Status:** ⏳ Pending
+
+### Step 5: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-067-split-config-by-concern/PROMPT.md
+++ b/taskplane-tasks/TP-067-split-config-by-concern/PROMPT.md
@@ -1,0 +1,105 @@
+# TP-067 — Split `internal/config/config.go` by concern (audit God-module)
+
+## Mission
+
+`internal/config/config.go` is 690 LOC and bundles seven responsibilities:
+
+- `Load` (file + env composition)
+- `validate` (~88 LOC single function with per-field branching)
+- atomic file write (`writeConfigFile`)
+- athlete-ID parse / normalize
+- HTTP bind validation/normalization (5 helpers, ~50 LOC)
+- `.env` parsing
+- default-path resolution
+- redaction / `String()`
+- raw-config merge
+
+Goal: split by concern into focused files inside the same package. Same exported names, same signatures.
+
+Suggested layout:
+
+- `config.go` — types, defaults, public `Load` entry point.
+- `load.go` — composition of file + env + flag inputs.
+- `validate.go` — sliced per-field (FTP, HR, bind, etc.).
+- `write.go` — atomic-write helpers.
+- `athlete.go` — athlete-ID parsing/normalization.
+- `httpbind.go` — HTTP bind validation and normalization.
+- `dotenv.go` — `.env` parsing.
+- `redaction.go` — `String()` (and `LogValue()` once TP-062 lands).
+
+Audit ref: 2026-05-16 Go audit, God-module section.
+
+PRD anchors: §7.1 setup / config; §7.3 transport (HTTP bind); §7.4 reliability.
+CLAUDE.md hard rules: small files; keychain-only secrets; never log API keys.
+
+Complexity: Blast radius 2 (config package internal; callers unchanged), Pattern novelty 1, Security 2 (validation correctness must not regress), Reversibility 1 = 6 → Review Level 1. Size: S.
+
+## Dependencies
+
+- **TP-049** Step 3 — `DebugMetadata` env read moves into `config.Load`. Sequence after TP-049 so the new env read lands at the right home.
+- **TP-062** — soft. If TP-062 has added `LogValue`, place it in `redaction.go`. If not yet landed, leave a TODO marker for TP-062 to slot into the new file.
+
+## Context to Read First
+
+- `internal/config/config.go` — full file.
+- `internal/config/config_test.go` — golden coverage.
+- TP-049 PROMPT.md — to know whether the env-read move has happened.
+- Any caller of `internal/config` (very small surface).
+
+## File Scope
+
+- Inside `internal/config/`: split per the layout above.
+- Tests: split alongside the source split where it improves clarity (e.g., `validate_test.go`, `httpbind_test.go`).
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- Changing validation rules.
+- Changing config file format / paths.
+- Changing exported names or signatures.
+- Adding new config fields.
+
+## Steps
+
+### Step 1: Inventory
+- [ ] List every top-level decl in `config.go` and assign each to a target file. Record in `STATUS.md`.
+- [ ] Slice `validate` into per-field sub-validators (e.g., `validateFTP`, `validateHTTPBind`) — same total logic.
+
+### Step 2: Mechanical split
+- [ ] One commit per file extraction. Run tests after each.
+- [ ] Slice the `validate` body into per-field functions, called in the same order from a single `validate` entry point. No logic change.
+
+### Step 3: Verify
+- [ ] `make build` / `test` / `test-race` / `lint`.
+- [ ] Round-trip test: load a fixture config, write it, reload it — output must be byte-identical to pre-refactor.
+- [ ] `wc -l internal/config/*.go` — each file ≤ ~250 LOC.
+
+## Acceptance Criteria
+
+- `internal/config/config.go` holds only types + defaults + public entry point.
+- Each concern lives in its own file.
+- `validate` is sliced into per-field functions.
+- Exported names and signatures unchanged.
+- All `make` checks pass.
+- Round-trip test gates byte-identical config IO.
+
+## Do NOT
+
+- Do not change config file format, paths, or env-var names.
+- Do not change validation rules. Same rules, smaller functions.
+- Do not collapse into a giant single commit — reviewers need per-file diffs.
+- Do not add new config fields.
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Changed" (internal refactor).
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-067`. One commit per extracted file.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-067-split-config-by-concern/STATUS.md
+++ b/taskplane-tasks/TP-067-split-config-by-concern/STATUS.md
@@ -1,0 +1,20 @@
+# TP-067-split-config-by-concern — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open  (blocked on TP-049)
+**Last Updated:** 2026-05-16
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** S
+
+---
+
+### Step 1: Inventory
+**Status:** ⏳ Pending
+
+### Step 2: Mechanical split
+**Status:** ⏳ Pending
+
+### Step 3: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-068-split-setup-and-extract-prompter/PROMPT.md
+++ b/taskplane-tasks/TP-068-split-setup-and-extract-prompter/PROMPT.md
@@ -1,0 +1,104 @@
+# TP-068 — Split `internal/app/setup.go` and extract reusable `terminalPrompter` (audit God-module)
+
+## Mission
+
+`internal/app/setup.go` is 562 LOC and packs three concerns:
+
+- CLI arg parsing + help (`parseSetupArgs`, `resolveSetupConfigPath`, `runSetupCommand`).
+- The setup flow itself — `RunSetup` is ~113 LOC, borderline cyclomatic-heavy.
+- A generic `terminalPrompter` (~lines 492-562) that would serve other interactive commands.
+
+Goal:
+
+1. `internal/app/setup_cmd.go` — arg parsing + dispatch.
+2. `internal/app/setup_flow.go` — `RunSetup` and its step helpers.
+3. `internal/cli/prompt/` (new package) — lift `terminalPrompter` so future interactive commands can reuse it. Narrow interface (e.g., `Prompter.AskString`, `Prompter.AskYesNo`).
+
+This is the first step toward a `cli/` shared package; resist over-designing — only the methods `setup.go` already uses get exported.
+
+Audit ref: 2026-05-16 Go audit, God-module section.
+
+PRD anchors: §7.1 first-run onboarding.
+CLAUDE.md hard rules: small interfaces; `internal/` default home for non-exported helpers.
+
+Complexity: Blast radius 2 (app package internal; new `internal/cli/prompt` package), Pattern novelty 2 (new package), Security 1, Reversibility 2 = 7 → Review Level 2. Size: M.
+
+## Dependencies
+
+- **TP-038** (first-run onboarding) — context only; behaviour must not regress.
+- **TP-049** Step 3 — sequence after (env-read move). Re-baseline against the post-TP-049 file.
+
+## Context to Read First
+
+- `internal/app/setup.go` — full file.
+- `internal/app/setup_test.go` — locked-in flow tests.
+- `internal/app/app.go` — to find any other consumer of the prompter (probably none yet).
+- TP-038 PROMPT.md + STATUS.md — flow semantics to preserve.
+
+## File Scope
+
+- `internal/app/setup_cmd.go` — `parseSetupArgs`, `resolveSetupConfigPath`, `runSetupCommand`.
+- `internal/app/setup_flow.go` — `RunSetup` plus step helpers (slice `RunSetup` into smaller helpers like `setupCollectAPIKey`, `setupVerifyConnection`, etc.).
+- `internal/cli/prompt/prompt.go` — `Prompter` interface + `Terminal` impl.
+- `internal/cli/prompt/prompt_test.go` — table-driven.
+- Tests in `internal/app/` — split alongside.
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- Changing the setup flow's user-visible steps or prompts.
+- Adding non-`setup` interactive commands.
+- Generalizing the prompter beyond the methods setup uses today.
+- Adding new dependencies (e.g., bubbletea / survey).
+
+## Steps
+
+### Step 1: Capture flow regression-gate
+- [ ] Ensure `setup_test.go` covers happy path + at least one error path (invalid API key, keychain error). If not, add tests.
+
+### Step 2: Slice `RunSetup`
+- [ ] Break the 113-LOC function into 4-6 step helpers in `setup_flow.go`. No logic change.
+- [ ] Run tests after the slice.
+
+### Step 3: Extract `cli/prompt`
+- [ ] Create `internal/cli/prompt/`. Move `terminalPrompter` + the minimal interface.
+- [ ] Update `internal/app/setup_flow.go` to import the new package.
+- [ ] Run tests.
+
+### Step 4: Split arg parsing
+- [ ] Move `parseSetupArgs`, `resolveSetupConfigPath`, `runSetupCommand` to `setup_cmd.go`.
+- [ ] Run tests.
+
+### Step 5: Verify
+- [ ] `make build` / `test` / `test-race` / `lint`.
+- [ ] Manual smoke: `bin/icuvisor setup --help` works; `bin/icuvisor setup` golden path works in a clean keychain.
+- [ ] `wc -l internal/app/setup*.go` — each ≤ ~300 LOC; `internal/cli/prompt/*.go` ≤ ~200 LOC.
+
+## Acceptance Criteria
+
+- `setup_cmd.go`, `setup_flow.go`, and `internal/cli/prompt/` exist as described.
+- `RunSetup` is sliced into step helpers; no helper > 60 LOC.
+- `internal/cli/prompt.Prompter` interface is minimal (only methods setup uses).
+- Setup flow output and prompts are byte-identical (smoke-test signoff in `STATUS.md`).
+- All `make` checks pass.
+
+## Do NOT
+
+- Do not change prompt wording, order, or defaults.
+- Do not add features (resume / non-interactive mode / etc.) in this task.
+- Do not introduce a third-party prompter library.
+- Do not export from `internal/cli/prompt` more than setup needs today.
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Changed" (internal refactor).
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-068`.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-068-split-setup-and-extract-prompter/STATUS.md
+++ b/taskplane-tasks/TP-068-split-setup-and-extract-prompter/STATUS.md
@@ -1,0 +1,26 @@
+# TP-068-split-setup-and-extract-prompter — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open  (blocked on TP-049)
+**Last Updated:** 2026-05-16
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** M
+
+---
+
+### Step 1: Capture flow regression-gate
+**Status:** ⏳ Pending
+
+### Step 2: Slice `RunSetup`
+**Status:** ⏳ Pending
+
+### Step 3: Extract `cli/prompt`
+**Status:** ⏳ Pending
+
+### Step 4: Split arg parsing
+**Status:** ⏳ Pending
+
+### Step 5: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-070-extract-sport-settings-zones/PROMPT.md
+++ b/taskplane-tasks/TP-070-extract-sport-settings-zones/PROMPT.md
@@ -1,0 +1,91 @@
+# TP-070 — Extract zones-merge logic from `internal/tools/update_sport_settings.go` (audit God-module)
+
+## Mission
+
+`internal/tools/update_sport_settings.go` (526 LOC) is a single tool — acceptable — but mixes:
+
+- arg decode and per-field validation (FTP, HR, pace)
+- **the zones merge** (gated by `ICUVISOR_DELETE_MODE`, the destructive-edit-sensitive path)
+- unit conversion
+- result shaping
+
+The zones-merge logic is the complex, dangerous part — it's the only path here that can wipe an athlete's custom zones. It should live in its own file with focused tests.
+
+Goal: extract `internal/tools/update_sport_settings_zones.go` (and `_test.go`) containing the zones-merge logic and its delete-mode gate. The main tool file shrinks and the dangerous code becomes greppable.
+
+Audit ref: 2026-05-16 Go audit, God-module section.
+
+PRD anchors: §7.2.C `update_sport_settings`; §7.2.D destructive-edit gating; safety policy in `internal/safety`.
+CLAUDE.md hard rules: destructive ops registration-time gated; never accept model-controlled confirm flags.
+
+Complexity: Blast radius 2 (tools package internal), Pattern novelty 1, Security 3 (zones overwrite is destructive), Reversibility 1 = 7 → Review Level 2. Size: S.
+
+## Dependencies
+
+- **TP-018** (delete-mode safety gate) — context only; behaviour must not regress.
+- **TP-022** (`update_sport_settings` originally) — context only.
+
+## Context to Read First
+
+- `internal/tools/update_sport_settings.go` — full file.
+- `internal/tools/update_sport_settings_test.go` — locked-in zones-merge cases.
+- `internal/safety/` — destructive-op gate currently in use.
+- PRD §7.2.D / §7.2.C `update_sport_settings` row.
+
+## File Scope
+
+- New: `internal/tools/update_sport_settings_zones.go` — the zones merge logic + delete-mode check.
+- New: `internal/tools/update_sport_settings_zones_test.go` — table-driven coverage for: no zones change (no gate needed), zones change in safe mode (rejected), zones change in destructive mode (allowed).
+- Trim: `internal/tools/update_sport_settings.go` — keep arg decode, FTP/HR/pace handling, result shaping; delegate the merge.
+- `CHANGELOG.md`, `STATUS.md`.
+
+Out of scope:
+- Changing the safety gate semantics or the env var name.
+- Adding model-controlled `confirm` parameters (forbidden by CLAUDE.md).
+- Changing zone structures or wire format.
+- Other parts of the tool (FTP, HR, pace).
+
+## Steps
+
+### Step 1: Lock in safety-gate regression tests
+- [ ] Verify the existing test file exercises: zones-edit blocked in safe mode; zones-edit allowed in destructive mode. If not, add the missing cases first.
+
+### Step 2: Extract
+- [ ] Move the zones-merge + delete-mode-check helpers to `update_sport_settings_zones.go`.
+- [ ] Update the main handler to call the helper.
+- [ ] Mirror the test split.
+
+### Step 3: Verify
+- [ ] `make build` / `test` / `test-race` / `lint`.
+- [ ] Adversarial safety tests (TP-028's set) all pass.
+- [ ] `scripts/snapshot_tool_schemas.go` diff empty.
+
+## Acceptance Criteria
+
+- Zones-merge logic lives in its own file with its own focused test.
+- Main `update_sport_settings.go` shrinks.
+- Safety-gate behaviour unchanged (regression tests prove it).
+- No model-controlled confirm flag introduced.
+- All `make` checks pass.
+
+## Do NOT
+
+- Do not change the destructive-op gate semantics or env var.
+- Do not introduce model-controlled overrides.
+- Do not change zone structures or wire format.
+- Do not extract FTP/HR/pace into separate files in this task — out of scope.
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` `[Unreleased]` under "Changed" (internal refactor).
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-070`.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-070-extract-sport-settings-zones/STATUS.md
+++ b/taskplane-tasks/TP-070-extract-sport-settings-zones/STATUS.md
@@ -1,0 +1,20 @@
+# TP-070-extract-sport-settings-zones — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** S
+
+---
+
+### Step 1: Lock in safety-gate regression tests
+**Status:** ⏳ Pending
+
+### Step 2: Extract
+**Status:** ⏳ Pending
+
+### Step 3: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-071-changelog-cut-release/PROMPT.md
+++ b/taskplane-tasks/TP-071-changelog-cut-release/PROMPT.md
@@ -1,0 +1,118 @@
+# TP-071 — Cut a tagged release before v0.5 internal-beta (CHANGELOG hygiene)
+
+## Mission
+
+The current `CHANGELOG.md` `[Unreleased]` section accumulates Wave 1–4 features (coach mode, setup subcommand, signed DMG, KR5 benchmark harness, full toolset, write tools, deletes). Meanwhile:
+
+- `ROADMAP.md` marks those items `[x]` complete.
+- `CLAUDE.md` "Build, test, release" describes a `tag vX.Y.Z` workflow that has not been exercised since the initial commit.
+- `docs/internal-beta/` is about to ship users a binary with no released version to install or refer to.
+
+Goal: cut a real release (most likely `v0.4.0`) before TP-041's v0.5 dogfood begins.
+
+Concretely:
+
+1. Decide the version (likely `v0.4.0` — the last fully-shipped wave per ROADMAP; **confirm with `git log` and ROADMAP**).
+2. Move all currently-unreleased entries under a new `## [v0.4.0] - YYYY-MM-DD` section in `CHANGELOG.md`.
+3. Run `make snapshot` (GoReleaser dry-run) and resolve any issues before tagging.
+4. Tag `v0.4.0` on `main`.
+5. Confirm the release workflow ran green.
+6. Update `docs/internal-beta/install.md` (if it exists) and any other doc that references a version, to point at the tag.
+
+Audit ref: 2026-05-16 documentation audit, CHANGELOG vs docs phasing mismatch.
+
+PRD anchors: §7.4 release process.
+CLAUDE.md hard rules: "Tag `vX.Y.Z` on `main` to trigger the release workflow. Tags are immutable."
+
+Complexity: Blast radius 3 (release artefact + docs), Pattern novelty 2 (first real tag), Security 2 (signing must work), Reversibility 1 (re-tag is forbidden; bad release → patch v0.4.1) = 8 → Review Level 2. Size: S.
+
+## Dependencies
+
+- **TP-055** (reconcile doc conflicts) — soft. If TP-055 lands first, CHANGELOG and ROADMAP are already in sync. If this lands first, leave TP-055 a clean post-release baseline to work from. Coordinate via STATUS.md.
+- **TP-037** (signed macOS installer) — must be working. Cutting a release that fails signing is worse than not cutting one.
+
+## Context to Read First
+
+- `CLAUDE.md` "Build, test, release" section.
+- `CHANGELOG.md` — current `[Unreleased]` block.
+- `ROADMAP.md` — checkbox state per wave.
+- `.github/workflows/release.yml` (or equivalent) — what runs on tag push.
+- `.goreleaser.yaml` (or `.goreleaser.yml`) — release artefact config.
+- `docs/internal-beta/install.md` if present.
+
+## File Scope
+
+- `CHANGELOG.md` — main edits.
+- `docs/internal-beta/install.md` and any other doc referencing a version.
+- README.md — if it mentions "unreleased" or a placeholder version, fix it.
+- `STATUS.md`.
+
+Out of scope:
+- Code changes — this is a release-hygiene task.
+- Changing release tooling beyond what `make snapshot` surfaces.
+- Bumping to v1.0 (the PRD has more to land before v1.0).
+- Pushing to any non-main branch.
+
+## Steps
+
+### Step 1: Confirm the version
+- [ ] Run `git tag --list` — should be empty or only prerelease tags. Record state.
+- [ ] Read ROADMAP.md and decide: is v0.4.0 the right tag, or should it be v0.4.0-beta.1? Record the decision and rationale in `STATUS.md`.
+- [ ] Get explicit human sign-off on the version number before tagging. (Tags are immutable.)
+
+### Step 2: CHANGELOG move
+- [ ] Move every entry currently under `[Unreleased]` into a new `## [v0.4.0] - 2026-05-16` (use the actual cut date) section.
+- [ ] Leave `[Unreleased]` empty (or seeded with TP-042..TP-070 entries already in flight).
+- [ ] Add a comparison link at the bottom (`[v0.4.0]: https://github.com/ricardocabral/icuvisor/releases/tag/v0.4.0`).
+
+### Step 3: Snapshot dry-run
+- [ ] `make snapshot`. Resolve any GoReleaser errors. Inspect the produced artefacts in `dist/`.
+- [ ] If signing locally is possible, verify the signed DMG opens. (TP-037 owns the signing infra; loop in if blocked.)
+
+### Step 4: Tag
+- [ ] Confirm `main` is clean and up-to-date.
+- [ ] `git tag -a v0.4.0 -m "Release v0.4.0"` (or signed tag if convention requires).
+- [ ] `git push origin v0.4.0`.
+- [ ] Watch the release workflow. If it fails, **do not retag** — open a fix PR and tag `v0.4.1` per CLAUDE.md.
+
+### Step 5: Update install/docs references
+- [ ] `docs/internal-beta/install.md` (or equivalent) points to `v0.4.0` artefacts.
+- [ ] Any "latest" version in README is consistent.
+
+### Step 6: Verify
+- [ ] GitHub Releases page shows `v0.4.0` with signed assets.
+- [ ] `gh release view v0.4.0` succeeds.
+- [ ] `bin/icuvisor --version` (after rebuilding) reports `v0.4.0`.
+- [ ] Commit: `TP-071 cut v0.4.0 release`.
+
+## Acceptance Criteria
+
+- `v0.4.0` (or agreed alternative) is tagged on `main`.
+- Release workflow succeeded; signed assets published.
+- `CHANGELOG.md` has a real `[v0.4.0]` section.
+- Install docs reference the tag.
+- No retag. Any fix is a `v0.4.1`.
+
+## Do NOT
+
+- Do not retag if the release workflow fails. Ship a patch.
+- Do not push the tag without human sign-off on the version number.
+- Do not tag from a branch other than `main`.
+- Do not include unreleased TP-042..TP-070 work in `v0.4.0` unless it has actually merged.
+- Do not bypass signing (`--no-gpg-sign`) or skip pre-flight checks.
+
+## Documentation
+
+- `STATUS.md`
+- `CHANGELOG.md` (main artefact)
+- Any install doc referencing a version.
+
+## Git Commit Convention
+
+Conventional Commits, prefixed `TP-071`. Tag message itself is `Release v0.4.0`.
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-071-changelog-cut-release/STATUS.md
+++ b/taskplane-tasks/TP-071-changelog-cut-release/STATUS.md
@@ -1,0 +1,29 @@
+# TP-071-changelog-cut-release — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open  (requires human sign-off on version)
+**Last Updated:** 2026-05-16
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** S
+
+---
+
+### Step 1: Confirm the version
+**Status:** ⏳ Pending
+
+### Step 2: CHANGELOG move
+**Status:** ⏳ Pending
+
+### Step 3: Snapshot dry-run
+**Status:** ⏳ Pending
+
+### Step 4: Tag
+**Status:** ⏳ Pending
+
+### Step 5: Update install/docs references
+**Status:** ⏳ Pending
+
+### Step 6: Verify
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/.reviews/R001-plan-step1.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/.reviews/R001-plan-step1.md
@@ -1,0 +1,21 @@
+# Plan Review: Step 1
+
+Status: Approved
+
+No blocking issues found with the Step 1 plan.
+
+I verified `internal/intervals/wellness.go` read-side tags for the target fields:
+
+- `SpO2` -> `json:"spO2"`
+- `VO2Max` -> `json:"vo2max"`
+- `Abdomen` -> `json:"abdomen"`
+- `Respiration` -> `json:"respiration"`
+- `MenstrualPhase` -> `json:"menstrualPhase"`
+
+The proposed client-layer changes are correctly scoped: add the five nullable fields to `WriteWellnessParams` and add matching `setSparse` entries in `writeWellnessBody` using the exact upstream keys above. This preserves existing sparse-update semantics and keeps validation/schema/tool exposure for later steps.
+
+Implementation notes:
+
+- Keep `VO2Max` as the Go field name and `"vo2max"` as the payload key, matching the existing read struct.
+- Keep `SpO2` casing consistent with the existing `Wellness.SpO2` field and `"spO2"` JSON key.
+- Do not add client-side trimming or enum validation for `MenstrualPhase` in Step 1; the current plan correctly leaves public argument validation to Step 2.

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/.reviews/R002-plan-step2.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/.reviews/R002-plan-step2.md
@@ -1,0 +1,15 @@
+# Plan Review: Step 2
+
+Status: Approved
+
+No blocking issues found with the Step 2 plan.
+
+I verified the current tool path in `internal/tools/update_wellness.go`: strict argument decoding depends on `updateWellnessRequest`, the public MCP schema comes from `updateWellnessInputSchema`, writes are mapped in `wellnessWriteParams`, and the top-level `_meta.fields_updated` echo is built by `updateWellnessFieldsUpdated`. The planned changes cover each required integration point for `spO2`, `vo2max`, `abdomen`, `respiration`, and `menstrualPhase`.
+
+Implementation notes:
+
+- Use Go field names consistent with the client/read structs: `SpO2 *float64`, `VO2Max *float64`, `Abdomen *float64`, `Respiration *float64`, and `MenstrualPhase *string`; keep JSON/schema keys exactly `spO2`, `vo2max`, `abdomen`, `respiration`, and `menstrualPhase`.
+- For the schema, include both `minimum` and `maximum` for `spO2` (`0..100`), and `minimum: 0` for the other numeric additions. Keep `menstrualPhase` as a string unless an upstream enum is verified from authoritative docs.
+- For `menstrualPhase` validation, reject nil only when absent is acceptable; when present, reject strings that are empty after `strings.TrimSpace`, so whitespace-only values do not count as valid writes.
+- Add the new fields to `updateWellnessFieldsUpdated`; also consider updating the category slices (`updateWellnessMeasurementFields` / `updateWellnessFreeTextFields`) so the helper capacity and field grouping remain self-documenting, even though they are currently only used for capacity.
+- Preserve the existing strict decoder and read-only field rejection behavior; this task should only expand the writable allow-list, not loosen unknown-field handling.

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/.reviews/R003-plan-step3.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/.reviews/R003-plan-step3.md
@@ -1,0 +1,15 @@
+# Plan Review: Step 3
+
+Status: Approved
+
+No blocking issues found with the Step 3 test plan. The planned table-driven coverage plus a combined-fields case maps to the task acceptance criteria for `spO2`, `vo2max`, `abdomen`, `respiration`, and `menstrualPhase`.
+
+Implementation notes:
+
+- Cover both layers explicitly:
+  - In `internal/tools/update_wellness_test.go`, assert the handler maps each new argument into `intervals.WriteWellnessParams` and that top-level `_meta.fields_updated` includes the exact public field name.
+  - In `internal/intervals/wellness_test.go` (or an equivalent existing test-server harness), assert the outbound PUT JSON body uses the exact upstream keys: `spO2`, `vo2max`, `abdomen`, `respiration`, and `menstrualPhase`. The case-sensitive `spO2` key is the issue-closing path.
+- Keep the individual cases table-driven and assert sparse semantics where practical: a single-field update should not accidentally include omitted new fields.
+- Validation coverage should include all new validations, not only the examples: `spO2 > 100` (and preferably `< 0`), negative `vo2max`, negative `abdomen`, negative `respiration`, and empty/whitespace-only `menstrualPhase`. Also assert validation failures do not call the writer.
+- The combined-fields test should write all five in one request and assert both the request mapping/body and `fields_updated` contain all five exact names. Because `fields_updated` is sorted, compare as a set or to sorted expected values rather than relying on input order.
+- Preserve existing strict-decoder/read-only tests; this step should add coverage without loosening unknown-field behavior.

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/.reviews/R004-plan-step4.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/.reviews/R004-plan-step4.md
@@ -1,0 +1,12 @@
+# Plan Review: Step 4
+
+Status: Approved
+
+No blocking issues found with the Step 4 verification plan. Running `make build`, `make test`, `make test-race`, and `make lint` matches the task acceptance criteria, and documenting whether the optional `.env-dev` smoke was run is the right handoff before Step 5.
+
+Implementation notes:
+
+- Also run `make fmt-check` or `make check` if practical. The prompt lists build/test/race/lint, but the repo rules require gofmt/goimports cleanliness and CI may fail on formatting even when `make lint` passes.
+- Record the exact command results in `STATUS.md` for this step, including any environment/tooling reason if `make lint` cannot run locally. Do not mark Step 4 complete on an uninvestigated failure.
+- If the optional live smoke is run, use only the `.env-dev` test athlete, avoid `locked: true`, save the pre-existing value for the chosen date if any, and either restore it or clearly document the intentionally written test value. Do not log API keys or paste secrets into the status file.
+- If the smoke is skipped, explicitly mark it as skipped/optional in `STATUS.md`; the automated verification commands are the acceptance-critical part of this step.

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/PROMPT.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/PROMPT.md
@@ -1,0 +1,127 @@
+# TP-072 — `update_wellness` missing write fields (`spO2`, `vo2max`, `abdomen`, `respiration`, `menstrualPhase`)
+
+## Mission
+
+Resolves [GitHub issue #8](https://github.com/ricardocabral/icuvisor/issues/8) — *TP-029: update_wellness schema lacks spO2 write field*.
+
+PRD §7.2.C (`docs/prd/PRD-icuvisor.md:248`) explicitly lists the writable wellness field set:
+
+> subjective scales (`feel`, `fatigue`, `soreness`, `stress`, `mood`, `motivation`, `sleepQuality`, `injury`), body metrics (`weight`, `bodyFat`, `abdomen`), cardiovascular (`restingHR`, `hrv`, `systolic`, `diastolic`), blood/lab (`bloodGlucose`, `lactate`, `spO2`, `vo2max`), respiration, menstrual phase, and the `locked` flag
+
+The current `update_wellness` tool is missing **five** of those: `spO2`, `vo2max`, `abdomen`, `respiration`, `menstrualPhase`. The TP-029 v0.3 dogfood (W-07) was blocked because `spO2` is not in the registered tool schema, so the LLM correctly refused a partial measurement write rather than silently dropping the field.
+
+This task adds the missing fields end-to-end (request struct, tool schema, client payload, tests) and closes #8.
+
+PRD anchors: §7.2.C wellness write field set (line 248).
+CLAUDE.md hard rules: rule 5 (tools terse by default, but schemas must be complete); MCP-server conventions ("Schemas matter").
+
+Complexity: Blast radius 1 (single tool + client), Pattern novelty 1 (mirror existing field pattern), Security 1, Reversibility 1 = 4 → Review Level 1. Size: S.
+
+## Dependencies
+
+- None. Independent of the other v0.2/v0.3 dogfood follow-ups (TP-073 through TP-077).
+- Issue #7 (TP-076 — `update_wellness` subjective write refused) is a separate live-API bug. If TP-076 finds that the subjective failure was a field that this task adds (e.g. spO2 was in the same bundle), coordinate the close on #7 there.
+
+## Context to Read First
+
+- [`docs/prd/PRD-icuvisor.md:237-254`](../../docs/prd/PRD-icuvisor.md) — wellness read + write field contract.
+- [`docs/dogfood/v0.3-findings.md`](../../docs/dogfood/v0.3-findings.md) lines 25–26 (W-07) and lines 117, 140, 152 — the dogfood evidence that this task closes.
+- [`internal/tools/update_wellness.go`](../../internal/tools/update_wellness.go) lines 63–83 (request struct), 105–133 (handler), 325–349 (input schema).
+- [`internal/intervals/wellness.go`](../../internal/intervals/wellness.go) lines 20–39 (`WriteWellnessParams`), 73 (read-struct `Wellness.SpO2` — proves field exists on the read side), 139–178 (`UpdateWellness` + `writeWellnessBody`).
+- [`internal/tools/update_wellness_test.go`](../../internal/tools/update_wellness_test.go) — existing test pattern for new field assertions.
+
+## File Scope
+
+- `internal/tools/update_wellness.go` — extend request struct, input schema, validation, `fields_updated` echo.
+- `internal/intervals/wellness.go` — add fields to `WriteWellnessParams`; extend `writeWellnessBody` with `setSparse` calls.
+- `internal/tools/update_wellness_test.go` — assert each new field round-trips into the request body and into the `fields_updated` response.
+- `CHANGELOG.md` — `[Unreleased]` under "Fixed" or "Added".
+- `STATUS.md` (this dir).
+
+Out of scope:
+- Refactoring the rest of `update_wellness` (handler shape, error mapping).
+- Adding new validation modes beyond simple non-negative range checks for numeric fields.
+- Touching the read-path `get_wellness_data` (it already surfaces these fields).
+
+## Steps
+
+### Step 1: Add fields to client write struct + payload
+
+- [ ] Read [`internal/intervals/wellness.go`](../../internal/intervals/wellness.go) to confirm the JSON field names used by the read struct (`Wellness`): `spO2`, `vo2max`, `abdomen`, `respiration`, `menstrualPhase` (or upstream casing — verify by grepping the read struct tags).
+- [ ] Add to `WriteWellnessParams`:
+  - `SpO2 *float64`
+  - `VO2Max *float64`
+  - `Abdomen *float64`
+  - `Respiration *float64`
+  - `MenstrualPhase *string`
+- [ ] Extend `writeWellnessBody` with matching `setSparse(body, "<upstream_key>", params.X)` lines using the exact JSON key the read struct uses.
+
+### Step 2: Expose fields in the tool
+
+- [ ] Extend `updateWellnessRequest` in `internal/tools/update_wellness.go` with the same five fields (JSON tags matching the input-schema names — keep camelCase: `spO2`, `vo2max`, `abdomen`, `respiration`, `menstrualPhase`).
+- [ ] Extend `updateWellnessInputSchema` with five new properties. For numeric ones, document the unit in the description (`"spO2: blood oxygen saturation percentage 0-100"`, `"vo2max: ml/kg/min"`, `"abdomen: cm"`, `"respiration: breaths per minute"`). For `menstrualPhase`: document the accepted enum if known, otherwise free-text string.
+- [ ] Add validation in the handler:
+  - `spO2` ∈ [0, 100]
+  - `vo2max` ≥ 0
+  - `abdomen` ≥ 0
+  - `respiration` ≥ 0
+  - `menstrualPhase` non-empty if provided (no enum gate until upstream contract is verified).
+- [ ] Wire the new fields into the request → `WriteWellnessParams` mapping in the handler.
+- [ ] Include them in `updateWellnessFieldsUpdated` (or whatever helper builds the `fields_updated` echo).
+
+### Step 3: Tests
+
+- [ ] Extend `update_wellness_test.go` with a table-driven case that writes one of each new field and asserts:
+  - The outbound HTTP body (use the existing fixture/test-server harness) contains the field under the correct JSON key.
+  - The response `fields_updated` includes the field name.
+  - Validation rejects out-of-range values (spO2 = 200, negative abdomen, empty menstrualPhase).
+- [ ] Add a single combined-fields test that writes all five at once.
+
+### Step 4: Build, lint, manual smoke
+
+- [ ] `make build`, `make test`, `make test-race`, `make lint`.
+- [ ] Manually smoke against `.env-dev` test athlete (optional but encouraged): a single `update_wellness` call with `spO2: 97` and a date in the recent past; re-read with `get_wellness_data` and confirm the field is present. Delete or `locked: false` cleanup afterward if you locked anything.
+
+### Step 5: Close the GitHub issue
+
+- [ ] Update `CHANGELOG.md` under `[Unreleased] → Fixed`: `update_wellness now accepts spO2, vo2max, abdomen, respiration, and menstrualPhase per PRD §7.2.C.`
+- [ ] Update `STATUS.md`.
+- [ ] Commit (Conventional Commits, lowercase, imperative): `fix(wellness): expose spO2/vo2max/abdomen/respiration/menstrualPhase on update_wellness (TP-072, closes #8)`.
+- [ ] Push the branch and either open a PR or fold into the combined v0.2/v0.3 dogfood follow-up PR if that pattern is being used. Reference `Closes #8` in the PR body.
+- [ ] After merge, verify the issue auto-closed; if it didn't, close manually with `gh issue close 8 --comment "Fixed in <commit-sha> / <PR>"`.
+
+## Acceptance Criteria
+
+- All five fields appear in: request struct, tool input schema, client write params, `writeWellnessBody`, and the response `fields_updated`.
+- Out-of-range values are rejected with a clear public error.
+- Unit tests cover each field individually and all-together.
+- `make build`, `make test`, `make test-race`, `make lint` all pass.
+- GitHub issue #8 is closed with a reference to the merging commit/PR.
+
+## Do NOT
+
+- Do not introduce a `confirm: true` argument (forbidden by CLAUDE.md hard rule 5 + MCP conventions). Destructive ops are env-gated, not LLM-gated.
+- Do not silently drop unknown fields. The current strict decoder is correct; preserve it.
+- Do not refactor `writeWellnessBody`'s `setSparse` helper unless adding a new field type genuinely requires it.
+- Do not change the `locked` field semantics — it's already correct.
+
+## Documentation
+
+- `CHANGELOG.md` `[Unreleased]` under "Fixed" (or "Added" if you consider new fields additive — both are defensible; Fixed matches the issue framing).
+- `STATUS.md` in this dir.
+
+## Git Commit Convention
+
+Conventional Commits, prefixed with TP-072 in the body. Example title:
+
+```
+fix(wellness): expose spO2/vo2max/abdomen/respiration/menstrualPhase on update_wellness
+
+TP-072. Closes #8.
+```
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
@@ -1,0 +1,27 @@
+# TP-072-update-wellness-missing-write-fields — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** S
+**Closes:** GitHub #8
+
+---
+
+### Step 1: Add fields to client write struct + payload
+**Status:** ⏳ Pending
+
+### Step 2: Expose fields in the tool
+**Status:** ⏳ Pending
+
+### Step 3: Tests
+**Status:** ⏳ Pending
+
+### Step 4: Build, lint, manual smoke
+**Status:** ⏳ Pending
+
+### Step 5: Close the GitHub issue
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
@@ -4,7 +4,7 @@
 **Status:** 🟡 In Progress
 **Last Updated:** 2026-05-16
 **Review Level:** 1
-**Review Counter:** 0
+**Review Counter:** 1
 **Iteration:** 1
 **Size:** S
 **Closes:** GitHub #8
@@ -12,11 +12,11 @@
 ---
 
 ### Step 1: Add fields to client write struct + payload
-**Status:** 🟨 In Progress
+**Status:** ✅ Complete
 
-- [ ] Verify read-side wellness JSON tags for `spO2`, `vo2max`, `abdomen`, `respiration`, and `menstrualPhase`.
-- [ ] Add missing fields to `WriteWellnessParams`.
-- [ ] Extend `writeWellnessBody` to include the new sparse payload keys.
+- [x] Verify read-side wellness JSON tags for `spO2`, `vo2max`, `abdomen`, `respiration`, and `menstrualPhase`.
+- [x] Add missing fields to `WriteWellnessParams`.
+- [x] Extend `writeWellnessBody` to include the new sparse payload keys.
 
 ### Step 2: Expose fields in the tool
 **Status:** ⏳ Pending
@@ -32,3 +32,4 @@
 
 | 2026-05-16 20:44 | Task started | Runtime V2 lane-runner execution |
 | 2026-05-16 20:44 | Step 1 started | Add fields to client write struct + payload |
+| 2026-05-16 20:46 | Review R001 | plan Step 1: APPROVE |

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
@@ -1,6 +1,6 @@
 # TP-072-update-wellness-missing-write-fields — Status
 
-**Current Step:** Step 2: Expose fields in the tool
+**Current Step:** Step 3: Tests
 **Status:** 🟡 In Progress
 **Last Updated:** 2026-05-16
 **Review Level:** 1
@@ -28,7 +28,10 @@
 - [x] Include the new fields in the `fields_updated` echo.
 
 ### Step 3: Tests
-**Status:** ⏳ Pending
+**Status:** 🟨 In Progress
+
+- [ ] Add table-driven coverage for each new field asserting outbound body keys, `fields_updated`, and validation failures.
+- [ ] Add a combined-fields test that writes all five new fields at once.
 
 ### Step 4: Build, lint, manual smoke
 **Status:** ⏳ Pending

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
@@ -43,8 +43,9 @@
 ### Step 5: Close the GitHub issue
 **Status:** 🟨 In Progress
 
-- [ ] Update `CHANGELOG.md` under `[Unreleased] → Fixed` with the missing `update_wellness` fields.
-- [ ] Update `STATUS.md` with final delivery notes.
+- [x] Update `CHANGELOG.md` under `[Unreleased] → Fixed` with the missing `update_wellness` fields.
+- [x] Update `STATUS.md` with final delivery notes.
+  - Delivery notes: added five missing wellness write fields end-to-end; validation covers `spO2`, non-negative numeric fields, and non-empty `menstrualPhase`; `make build`, `make test`, `make test-race`, and `make lint` passed.
 - [ ] Commit final documentation/status changes with a conventional commit referencing TP-072 and #8.
 - [ ] Push or document why push/PR handoff and post-merge issue closure cannot be completed from this lane.
 

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
@@ -4,7 +4,7 @@
 **Status:** 🟡 In Progress
 **Last Updated:** 2026-05-16
 **Review Level:** 1
-**Review Counter:** 2
+**Review Counter:** 3
 **Iteration:** 1
 **Size:** S
 **Closes:** GitHub #8
@@ -28,10 +28,10 @@
 - [x] Include the new fields in the `fields_updated` echo.
 
 ### Step 3: Tests
-**Status:** 🟨 In Progress
+**Status:** ✅ Complete
 
-- [ ] Add table-driven coverage for each new field asserting outbound body keys, `fields_updated`, and validation failures.
-- [ ] Add a combined-fields test that writes all five new fields at once.
+- [x] Add table-driven coverage for each new field asserting outbound body keys, `fields_updated`, and validation failures.
+- [x] Add a combined-fields test that writes all five new fields at once.
 
 ### Step 4: Build, lint, manual smoke
 **Status:** ⏳ Pending
@@ -43,3 +43,4 @@
 | 2026-05-16 20:44 | Step 1 started | Add fields to client write struct + payload |
 | 2026-05-16 20:46 | Review R001 | plan Step 1: APPROVE |
 | 2026-05-16 20:50 | Review R002 | plan Step 2: APPROVE |
+| 2026-05-16 20:54 | Review R003 | plan Step 3: APPROVE |

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
@@ -4,7 +4,7 @@
 **Status:** 🟡 In Progress
 **Last Updated:** 2026-05-16
 **Review Level:** 1
-**Review Counter:** 1
+**Review Counter:** 2
 **Iteration:** 1
 **Size:** S
 **Closes:** GitHub #8
@@ -19,13 +19,13 @@
 - [x] Extend `writeWellnessBody` to include the new sparse payload keys.
 
 ### Step 2: Expose fields in the tool
-**Status:** 🟨 In Progress
+**Status:** ✅ Complete
 
-- [ ] Extend `updateWellnessRequest` with the five new fields.
-- [ ] Extend `updateWellnessInputSchema` with documented properties for the new fields.
-- [ ] Add handler validation for numeric ranges and non-empty `menstrualPhase`.
-- [ ] Map the new request fields into `WriteWellnessParams`.
-- [ ] Include the new fields in the `fields_updated` echo.
+- [x] Extend `updateWellnessRequest` with the five new fields.
+- [x] Extend `updateWellnessInputSchema` with documented properties for the new fields.
+- [x] Add handler validation for numeric ranges and non-empty `menstrualPhase`.
+- [x] Map the new request fields into `WriteWellnessParams`.
+- [x] Include the new fields in the `fields_updated` echo.
 
 ### Step 3: Tests
 **Status:** ⏳ Pending
@@ -39,3 +39,4 @@
 | 2026-05-16 20:44 | Task started | Runtime V2 lane-runner execution |
 | 2026-05-16 20:44 | Step 1 started | Add fields to client write struct + payload |
 | 2026-05-16 20:46 | Review R001 | plan Step 1: APPROVE |
+| 2026-05-16 20:50 | Review R002 | plan Step 2: APPROVE |

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
@@ -1,6 +1,6 @@
 # TP-072-update-wellness-missing-write-fields — Status
 
-**Current Step:** Step 1: Add fields to client write struct + payload
+**Current Step:** Step 2: Expose fields in the tool
 **Status:** 🟡 In Progress
 **Last Updated:** 2026-05-16
 **Review Level:** 1
@@ -19,7 +19,13 @@
 - [x] Extend `writeWellnessBody` to include the new sparse payload keys.
 
 ### Step 2: Expose fields in the tool
-**Status:** ⏳ Pending
+**Status:** 🟨 In Progress
+
+- [ ] Extend `updateWellnessRequest` with the five new fields.
+- [ ] Extend `updateWellnessInputSchema` with documented properties for the new fields.
+- [ ] Add handler validation for numeric ranges and non-empty `menstrualPhase`.
+- [ ] Map the new request fields into `WriteWellnessParams`.
+- [ ] Include the new fields in the `fields_updated` echo.
 
 ### Step 3: Tests
 **Status:** ⏳ Pending

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
@@ -1,7 +1,7 @@
 # TP-072-update-wellness-missing-write-fields — Status
 
 **Current Step:** Step 5: Close the GitHub issue
-**Status:** 🟡 In Progress
+**Status:** ✅ Complete
 **Last Updated:** 2026-05-16
 **Review Level:** 1
 **Review Counter:** 4
@@ -41,13 +41,14 @@
   - Manual smoke not run: skipped optional live `.env-dev` write to avoid mutating athlete data in this automated lane; unit/integration tests cover request schema, payload mapping, validation, and response metadata.
 
 ### Step 5: Close the GitHub issue
-**Status:** 🟨 In Progress
+**Status:** ✅ Complete
 
 - [x] Update `CHANGELOG.md` under `[Unreleased] → Fixed` with the missing `update_wellness` fields.
 - [x] Update `STATUS.md` with final delivery notes.
   - Delivery notes: added five missing wellness write fields end-to-end; validation covers `spO2`, non-negative numeric fields, and non-empty `menstrualPhase`; `make build`, `make test`, `make test-race`, and `make lint` passed.
-- [ ] Commit final documentation/status changes with a conventional commit referencing TP-072 and #8.
-- [ ] Push or document why push/PR handoff and post-merge issue closure cannot be completed from this lane.
+- [x] Commit final documentation/status changes with a conventional commit referencing TP-072 and #8.
+- [x] Push or document why push/PR handoff and post-merge issue closure cannot be completed from this lane.
+  - Pushed branch `task/jusbrasil-lane-2-20260516T174422` and opened PR https://github.com/ricardocabral/icuvisor/pull/14 with `Closes #8`; post-merge issue auto-close verification remains pending merge.
 
 | 2026-05-16 20:44 | Task started | Runtime V2 lane-runner execution |
 | 2026-05-16 20:44 | Step 1 started | Add fields to client write struct + payload |

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
@@ -4,7 +4,7 @@
 **Status:** 🟡 In Progress
 **Last Updated:** 2026-05-16
 **Review Level:** 1
-**Review Counter:** 3
+**Review Counter:** 4
 **Iteration:** 1
 **Size:** S
 **Closes:** GitHub #8
@@ -34,10 +34,11 @@
 - [x] Add a combined-fields test that writes all five new fields at once.
 
 ### Step 4: Build, lint, manual smoke
-**Status:** 🟨 In Progress
+**Status:** ✅ Complete
 
-- [ ] Run `make build`, `make test`, `make test-race`, and `make lint` successfully.
-- [ ] Decide and document whether the optional `.env-dev` manual smoke was run.
+- [x] Run `make build`, `make test`, `make test-race`, and `make lint` successfully.
+- [x] Decide and document whether the optional `.env-dev` manual smoke was run.
+  - Manual smoke not run: skipped optional live `.env-dev` write to avoid mutating athlete data in this automated lane; unit/integration tests cover request schema, payload mapping, validation, and response metadata.
 
 ### Step 5: Close the GitHub issue
 **Status:** ⏳ Pending
@@ -47,3 +48,4 @@
 | 2026-05-16 20:46 | Review R001 | plan Step 1: APPROVE |
 | 2026-05-16 20:50 | Review R002 | plan Step 2: APPROVE |
 | 2026-05-16 20:54 | Review R003 | plan Step 3: APPROVE |
+| 2026-05-16 20:59 | Review R004 | plan Step 4: APPROVE |

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
@@ -1,18 +1,22 @@
 # TP-072-update-wellness-missing-write-fields — Status
 
-**Current Step:** Not started
-**Status:** ⏳ Open
+**Current Step:** Step 1: Add fields to client write struct + payload
+**Status:** 🟡 In Progress
 **Last Updated:** 2026-05-16
 **Review Level:** 1
 **Review Counter:** 0
-**Iteration:** 0
+**Iteration:** 1
 **Size:** S
 **Closes:** GitHub #8
 
 ---
 
 ### Step 1: Add fields to client write struct + payload
-**Status:** ⏳ Pending
+**Status:** 🟨 In Progress
+
+- [ ] Verify read-side wellness JSON tags for `spO2`, `vo2max`, `abdomen`, `respiration`, and `menstrualPhase`.
+- [ ] Add missing fields to `WriteWellnessParams`.
+- [ ] Extend `writeWellnessBody` to include the new sparse payload keys.
 
 ### Step 2: Expose fields in the tool
 **Status:** ⏳ Pending
@@ -25,3 +29,6 @@
 
 ### Step 5: Close the GitHub issue
 **Status:** ⏳ Pending
+
+| 2026-05-16 20:44 | Task started | Runtime V2 lane-runner execution |
+| 2026-05-16 20:44 | Step 1 started | Add fields to client write struct + payload |

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
@@ -1,6 +1,6 @@
 # TP-072-update-wellness-missing-write-fields — Status
 
-**Current Step:** Step 3: Tests
+**Current Step:** Step 4: Build, lint, manual smoke
 **Status:** 🟡 In Progress
 **Last Updated:** 2026-05-16
 **Review Level:** 1
@@ -34,7 +34,10 @@
 - [x] Add a combined-fields test that writes all five new fields at once.
 
 ### Step 4: Build, lint, manual smoke
-**Status:** ⏳ Pending
+**Status:** 🟨 In Progress
+
+- [ ] Run `make build`, `make test`, `make test-race`, and `make lint` successfully.
+- [ ] Decide and document whether the optional `.env-dev` manual smoke was run.
 
 ### Step 5: Close the GitHub issue
 **Status:** ⏳ Pending

--- a/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
+++ b/taskplane-tasks/TP-072-update-wellness-missing-write-fields/STATUS.md
@@ -1,6 +1,6 @@
 # TP-072-update-wellness-missing-write-fields — Status
 
-**Current Step:** Step 4: Build, lint, manual smoke
+**Current Step:** Step 5: Close the GitHub issue
 **Status:** 🟡 In Progress
 **Last Updated:** 2026-05-16
 **Review Level:** 1
@@ -41,7 +41,12 @@
   - Manual smoke not run: skipped optional live `.env-dev` write to avoid mutating athlete data in this automated lane; unit/integration tests cover request schema, payload mapping, validation, and response metadata.
 
 ### Step 5: Close the GitHub issue
-**Status:** ⏳ Pending
+**Status:** 🟨 In Progress
+
+- [ ] Update `CHANGELOG.md` under `[Unreleased] → Fixed` with the missing `update_wellness` fields.
+- [ ] Update `STATUS.md` with final delivery notes.
+- [ ] Commit final documentation/status changes with a conventional commit referencing TP-072 and #8.
+- [ ] Push or document why push/PR handoff and post-merge issue closure cannot be completed from this lane.
 
 | 2026-05-16 20:44 | Task started | Runtime V2 lane-runner execution |
 | 2026-05-16 20:44 | Step 1 started | Add fields to client write struct + payload |

--- a/taskplane-tasks/TP-073-get-workouts-in-folder-terse-description/PROMPT.md
+++ b/taskplane-tasks/TP-073-get-workouts-in-folder-terse-description/PROMPT.md
@@ -1,0 +1,110 @@
+# TP-073 — Move `get_workouts_in_folder` description behind `include_full`
+
+## Mission
+
+Resolves [GitHub issue #12](https://github.com/ricardocabral/icuvisor/issues/12) — *TP-016: review `get_workouts_in_folder` default verbosity*.
+
+PRD §7.2.D + CLAUDE.md hard rule 5 require tools to be terse by default; heavy payloads sit behind `include_full: true`. The v0.2 dogfood (TP-016) found that `get_workouts_in_folder` currently includes the full `description` field (which can be multi-paragraph coaching prose) in its terse default response. The response size stayed below the 30k-token soft ceiling, but coaching-prose descriptions consume conversation budget unnecessarily when the LLM is iterating over a folder listing.
+
+Fix: drop `description` from the terse default; keep it behind `include_full: true` alongside the existing `workout_doc` opt-in.
+
+PRD anchors: §7.2.D terse-by-default contract; line 332 (~30k-token soft ceiling).
+CLAUDE.md: hard rule 5.
+
+Complexity: Blast radius 1, Pattern novelty 1 (matches existing `workout_doc` gating in the same file), Security 1, Reversibility 1 = 4 → Review Level 1. Size: XS.
+
+## Dependencies
+
+- None. Independent of the other v0.2/v0.3 dogfood follow-ups (TP-072, TP-074, TP-075, TP-076, TP-077).
+- Aligns conceptually with the `get_workout_library` terse pattern at the folder level. Do NOT change `get_workout_library` (folder-level descriptions are short metadata; keeping them terse is fine).
+
+## Context to Read First
+
+- [`docs/prd/PRD-icuvisor.md`](../../docs/prd/PRD-icuvisor.md) §7.2.D — terse-by-default contract.
+- [`docs/dogfood/v0.2-findings.md`](../../docs/dogfood/v0.2-findings.md) lines around `get_workouts_in_folder` (search for the tool name) — the dogfood verdict.
+- [`taskplane-tasks/TP-016-v02-dogfood-validation/STATUS.md`](../TP-016-v02-dogfood-validation/STATUS.md) — original follow-up tracking.
+- [`internal/tools/get_workouts_in_folder.go`](../../internal/tools/get_workouts_in_folder.go):
+  - Response struct `workoutInFolderRow`: lines 30–45.
+  - Shaping `workoutInFolderToRow()`: lines 119–128.
+  - Input schema: lines 130–135 (confirm `include_full` is already declared — it is, since `workout_doc` already uses it).
+- [`internal/tools/get_workout_library_test.go`](../../internal/tools/get_workout_library_test.go):
+  - `TestGetWorkoutsInFolderFiltersAndPreservesWorkoutDocWithIncludeFull`: lines 118–155.
+  - `TestGetWorkoutsInFolderHidesWorkoutDocByDefault`: lines 157–177.
+
+## File Scope
+
+- `internal/tools/get_workouts_in_folder.go` — gate `description` behind `includeFull`.
+- `internal/tools/get_workout_library_test.go` — extend the two existing tests; add an explicit "description hidden by default" assertion.
+- `CHANGELOG.md` — `[Unreleased]` under "Changed" (this is a default-response shape change; document it clearly).
+- `STATUS.md` (this dir).
+
+Out of scope:
+- Changing `get_workout_library` (folder listings stay as-is).
+- Changing any other field on `workoutInFolderRow`.
+- Restructuring the tool's input schema.
+
+## Steps
+
+### Step 1: Reproduce the verbose default in a test
+
+- [ ] In `TestGetWorkoutsInFolderHidesWorkoutDocByDefault` (line 157), add an assertion that `description` is also absent from the terse default row.
+- [ ] Confirm the test fails on `main`.
+
+### Step 2: Fix the shaping function
+
+- [ ] In `workoutInFolderToRow()`, only populate the `Description` field when `includeFull` is true. (Either pass `includeFull` into the helper, or null the field after-the-fact in the caller — match the existing pattern used for `workout_doc`.)
+- [ ] Keep `workout_doc_summary` in terse mode if it's already present (the dogfood note didn't flag it).
+
+### Step 3: Tests
+
+- [ ] Extend `TestGetWorkoutsInFolderFiltersAndPreservesWorkoutDocWithIncludeFull` (line 118) to assert `description` IS present when `include_full: true`.
+- [ ] Confirm the modified terse test from Step 1 now passes.
+- [ ] Run `make test` and `make test-race`.
+
+### Step 4: Build + lint
+
+- [ ] `make build`, `make lint`.
+
+### Step 5: Close the GitHub issue
+
+- [ ] Update `CHANGELOG.md` under `[Unreleased] → Changed`: `get_workouts_in_folder no longer includes workout descriptions in the terse default response; set include_full: true to access them.`
+- [ ] Update `STATUS.md`.
+- [ ] Commit: `fix(workouts): gate description behind include_full in get_workouts_in_folder (TP-073, closes #12)`.
+- [ ] Reference `Closes #12` in the PR body. After merge, verify auto-close; otherwise `gh issue close 12 --comment "Fixed in <commit-sha> / <PR>"`.
+
+## Acceptance Criteria
+
+- `description` is absent from `get_workouts_in_folder` rows when `include_full` is false (the default).
+- `description` is present when `include_full: true`.
+- Both tests pass; both terse-and-full coverage paths are explicit.
+- `make build`, `make test`, `make test-race`, `make lint` clean.
+- CHANGELOG entry under "Changed" makes the default-shape change explicit (LLM operators may have prompts that assume `description` is present — they need a heads-up).
+- GitHub issue #12 closed.
+
+## Do NOT
+
+- Do not drop `description` from `workoutInFolderRow` entirely — `include_full: true` callers still need it.
+- Do not change `get_workout_library`'s folder-level `description` field; it's short metadata and the dogfood didn't flag it.
+- Do not introduce a new opt-in argument; reuse the existing `include_full` flag.
+- Do not silently rename the field. Schemas are additive-only per the v0.2 stability rules.
+
+## Documentation
+
+- `CHANGELOG.md` `[Unreleased]` under "Changed".
+- `STATUS.md` in this dir.
+
+## Git Commit Convention
+
+Conventional Commits, prefixed with TP-073. Example:
+
+```
+fix(workouts): gate description behind include_full in get_workouts_in_folder
+
+TP-073. Closes #12.
+```
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-073-get-workouts-in-folder-terse-description/STATUS.md
+++ b/taskplane-tasks/TP-073-get-workouts-in-folder-terse-description/STATUS.md
@@ -1,0 +1,27 @@
+# TP-073-get-workouts-in-folder-terse-description — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** XS
+**Closes:** GitHub #12
+
+---
+
+### Step 1: Reproduce the verbose default in a test
+**Status:** ⏳ Pending
+
+### Step 2: Fix the shaping function
+**Status:** ⏳ Pending
+
+### Step 3: Tests
+**Status:** ⏳ Pending
+
+### Step 4: Build + lint
+**Status:** ⏳ Pending
+
+### Step 5: Close the GitHub issue
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-074-activity-detail-fetch-fallback/PROMPT.md
+++ b/taskplane-tasks/TP-074-activity-detail-fetch-fallback/PROMPT.md
@@ -1,0 +1,134 @@
+# TP-074 — Activity detail read tools: broaden upstream-error fallback + structured `unavailable` shape
+
+## Mission
+
+Resolves [GitHub issue #11](https://github.com/ricardocabral/icuvisor/issues/11) — *TP-016: investigate activity detail read fetch failures*.
+
+The v0.2 dogfood (TP-016) found that `get_activity_intervals`, `get_activity_streams`, `get_activity_splits`, and `get_extended_metrics` returned generic fetch-failure errors against real activity IDs. The tools correctly avoided fabricating data, but the public error was uninformative — operators couldn't distinguish "Strava-blocked activity" from "bad ID" from "intervals.icu hiccup".
+
+Root cause (from triage):
+
+1. `isActivityReadFallbackCandidate` in [`internal/tools/get_activity_details.go:219-221`](../../internal/tools/get_activity_details.go) only catches `intervals.ErrNotFound` and `intervals.ErrUnauthorized`. Upstream 400 / 5xx are mapped to `intervals.ErrUpstream` ([`internal/intervals/errors.go:50-61`](../../internal/intervals/errors.go)) and bypass the Strava-block fallback entirely.
+2. The fallback path that *does* detect a Strava-blocked activity already returns a structured `unavailable: { reason, workaround }`. We just need to route more error classes into it.
+3. When the fallback also fails (e.g. true 5xx from upstream), the generic message obscures the real cause.
+
+Fix: extend the fallback predicate, and make the terminal error surface a structured `unavailable: { reason: "..." }` shape with categories: `strava_blocked`, `not_found`, `unauthorized`, `upstream_unavailable`, `unknown`.
+
+PRD anchors: §7.2.C activity read cluster; §7.4 reliability; Strava-blocked-activity detection (v0.2 roadmap, already implemented for `get_activities`).
+CLAUDE.md: errors back to the LLM "short, actionable, and free of internal stack traces."
+
+Complexity: Blast radius 2 (four tools share the predicate), Pattern novelty 2 (introduces a new categorized `unavailable` shape on a new code path), Security 1, Reversibility 2 = 7 → Review Level 2. Size: M.
+
+## Dependencies
+
+- None. Independent of the other v0.2/v0.3 dogfood follow-ups (TP-072, TP-073, TP-075, TP-076, TP-077).
+- Related: the `get_activities` tool already implements `isStravaBlocked` ([`internal/tools/get_activities.go:1127-1130`](../../internal/tools/get_activities.go)) — reuse its detection logic; do not duplicate.
+
+## Context to Read First
+
+- [`docs/dogfood/v0.2-findings.md`](../../docs/dogfood/v0.2-findings.md) — search for T-08, T-09, T-10, T-12 for the exact observed error text.
+- [`taskplane-tasks/TP-016-v02-dogfood-validation/STATUS.md`](../TP-016-v02-dogfood-validation/STATUS.md) — original follow-up tracking.
+- [`internal/intervals/errors.go:50-61`](../../internal/intervals/errors.go) — `errorForStatus()` HTTP→sentinel mapping. Note 400 is NOT explicitly mapped (falls through to `ErrUpstream`).
+- [`internal/intervals/activity_details.go:131-144`](../../internal/intervals/activity_details.go) — `GetActivityIntervals` + sibling client methods.
+- [`internal/tools/get_activity_details.go:139-221`](../../internal/tools/get_activity_details.go) — handler + `isActivityReadFallbackCandidate`.
+- [`internal/tools/get_activity_streams.go`](../../internal/tools/get_activity_streams.go) — sibling tool error path.
+- [`internal/tools/get_activity_splits.go`](../../internal/tools/get_activity_splits.go) — sibling tool error path.
+- [`internal/tools/get_extended_metrics.go:97-160`](../../internal/tools/get_extended_metrics.go) — sibling tool error path.
+- [`internal/tools/get_activities.go:1127-1130`](../../internal/tools/get_activities.go) — existing `isStravaBlocked` helper.
+
+## File Scope
+
+- `internal/tools/get_activity_details.go` — broaden fallback predicate; add structured `unavailable` shape for terminal errors.
+- `internal/tools/get_activity_streams.go`, `internal/tools/get_activity_splits.go`, `internal/tools/get_extended_metrics.go` — mirror the new error shape.
+- `internal/intervals/errors.go` — *optional* — add explicit 400 → `ErrBadRequest` mapping if doing so simplifies the predicate; otherwise leave alone.
+- `internal/intervals/testdata/` — new fixtures for 400 / 403 / 5xx responses on intervals/streams/splits endpoints.
+- New / extended `_test.go` files for each tool covering: Strava block path, 404 path, 5xx path, success path.
+- `CHANGELOG.md` — `[Unreleased]` under "Fixed".
+- `STATUS.md` (this dir).
+
+Out of scope:
+- Refactoring the four tools into a shared base (each is small enough; not worth the abstraction).
+- Adding retry logic for transient 5xx — that's `httpretry`'s job and is already configured at client level.
+- Changing the success-path response shape.
+
+## Steps
+
+### Step 1: Add failing tests for each error class
+
+- [ ] For each of the four tools, write a test that uses an `httptest.Server` returning, in sequence:
+  - 403 on the detail endpoint + a Strava-marked activity payload available via `GetActivity` → expect `unavailable: { reason: "strava_blocked", workaround: "<msg>" }`.
+  - 404 → expect `unavailable: { reason: "not_found" }`.
+  - 500 → expect `unavailable: { reason: "upstream_unavailable" }`.
+  - 400 → expect `unavailable: { reason: "upstream_unavailable" }` (or `"bad_request"` if you choose to map it explicitly).
+- [ ] Confirm all the new tests fail on `main` (or partially fail — some 403 cases may already pass).
+
+### Step 2: Broaden the fallback predicate
+
+- [ ] Update `isActivityReadFallbackCandidate` to also accept `intervals.ErrUpstream` (so 400 / 5xx route into the Strava-block check).
+- [ ] Inside the fallback: if the `GetActivity` fetch succeeds and `isStravaBlocked(activity)` is true → return the `strava_blocked` `unavailable` shape.
+- [ ] If the fallback `GetActivity` also fails or the activity isn't Strava-blocked → return a *categorized* `unavailable` shape based on the original sentinel:
+  - `ErrNotFound` → `not_found`
+  - `ErrUnauthorized` → `unauthorized`
+  - `ErrRateLimited` → `rate_limited`
+  - `ErrUpstream` (or anything else) → `upstream_unavailable`
+
+### Step 3: Mirror the shape across the four tools
+
+- [ ] Extract a small helper (e.g. `internal/tools/activity_unavailable.go`) that takes `(ctx, client, athleteID, activityID, err) → (unavailableShape, classifiedErr)` so the four tools share one categorization path.
+- [ ] Wire `get_activity_intervals`, `get_activity_streams`, `get_activity_splits`, `get_extended_metrics` to use it.
+
+### Step 4: Fixtures
+
+- [ ] Add `internal/intervals/testdata/activity_intervals_strava_blocked_403.json` (or wire the test server inline if no fixture body is needed — 403 with empty body is enough).
+- [ ] Add `internal/intervals/testdata/activity_streams_not_found_404.json`.
+- [ ] Add `internal/intervals/testdata/activity_splits_500.json` (empty body, just status).
+- [ ] Keep fixtures minimal — favour inline `httptest.Server` over JSON files when there's no shape to assert.
+
+### Step 5: Build + lint + race + manual smoke
+
+- [ ] `make build`, `make test`, `make test-race`, `make lint`.
+- [ ] Manual smoke (optional but encouraged) using `.env-dev`: pick a real Strava-imported activity on the test athlete (or any failing activity from the v0.2 findings) and call `get_activity_intervals` via stdio MCP. Confirm the new structured `unavailable` shape.
+
+### Step 6: Close the GitHub issue
+
+- [ ] Update `CHANGELOG.md` under `[Unreleased] → Fixed`: `activity detail read tools (get_activity_intervals/streams/splits, get_extended_metrics) now return a structured unavailable:{reason} shape covering strava_blocked, not_found, unauthorized, rate_limited, and upstream_unavailable instead of a generic fetch error.`
+- [ ] Update `STATUS.md`.
+- [ ] Commit: `fix(activities): categorize unavailable responses for activity detail reads (TP-074, closes #11)`.
+- [ ] Reference `Closes #11` in the PR body. After merge, verify auto-close; otherwise `gh issue close 11 --comment "Fixed in <commit-sha> / <PR>"`.
+
+## Acceptance Criteria
+
+- All four tools (`get_activity_intervals`, `get_activity_streams`, `get_activity_splits`, `get_extended_metrics`) emit `unavailable: { reason: "<category>" }` rather than a generic error string when upstream fails.
+- `reason` ∈ { `strava_blocked`, `not_found`, `unauthorized`, `rate_limited`, `upstream_unavailable` }. `strava_blocked` also includes a `workaround` field.
+- The fallback predicate covers `ErrUpstream` so 400 / 5xx routes through Strava detection.
+- Each tool has tests covering all four error classes plus a success-path test.
+- `make build`, `make test`, `make test-race`, `make lint` pass.
+- GitHub issue #11 closed.
+
+## Do NOT
+
+- Do not change the success-path response shape — schema stability per v0.2 contract.
+- Do not retry the upstream call yourself — `httpretry` handles transient 5xx at the client layer.
+- Do not log activity IDs or athlete IDs in a way that's hard to scrub later (CLAUDE.md: "Never log API keys, tokens, or raw athlete identifiers in a way that's hard to scrub later").
+- Do not introduce a new sentinel error class unless `errors.Is`/`errors.As` callers actually need it. Reuse `ErrUpstream` and friends.
+
+## Documentation
+
+- `CHANGELOG.md` `[Unreleased]` under "Fixed".
+- `STATUS.md` in this dir.
+
+## Git Commit Convention
+
+Conventional Commits, prefixed with TP-074. Example:
+
+```
+fix(activities): categorize unavailable responses for activity detail reads
+
+TP-074. Closes #11.
+```
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-074-activity-detail-fetch-fallback/STATUS.md
+++ b/taskplane-tasks/TP-074-activity-detail-fetch-fallback/STATUS.md
@@ -1,0 +1,30 @@
+# TP-074-activity-detail-fetch-fallback — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** M
+**Closes:** GitHub #11
+
+---
+
+### Step 1: Add failing tests for each error class
+**Status:** ⏳ Pending
+
+### Step 2: Broaden the fallback predicate
+**Status:** ⏳ Pending
+
+### Step 3: Mirror the shape across the four tools
+**Status:** ⏳ Pending
+
+### Step 4: Fixtures
+**Status:** ⏳ Pending
+
+### Step 5: Build + lint + race + manual smoke
+**Status:** ⏳ Pending
+
+### Step 6: Close the GitHub issue
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-075-add-or-update-event-note-create/PROMPT.md
+++ b/taskplane-tasks/TP-075-add-or-update-event-note-create/PROMPT.md
@@ -1,0 +1,134 @@
+# TP-075 — `add_or_update_event` NOTE category create refused
+
+## Mission
+
+Resolves [GitHub issue #6](https://github.com/ricardocabral/icuvisor/issues/6) — *TP-029: `add_or_update_event` NOTE create refused during dogfood*.
+
+During the v0.3 dogfood (TP-029, W-01 in [`docs/dogfood/v0.3-findings.md:19`](../../docs/dogfood/v0.3-findings.md)), creating a synthetic NOTE event named `TP-029 dogfood note` against the dedicated test athlete failed: the upstream POST was refused, and a same-day `get_events` re-read showed zero synthetic events. The structured WORKOUT create on W-03 in the same run passed, so the failure is specific to the NOTE category code path — not the tool wiring overall.
+
+Suspected defects (from triage, ordered by likelihood — confirm via live probe):
+
+1. **Date format gating** — [`internal/tools/add_or_update_event.go:189-193`](../../internal/tools/add_or_update_event.go) appends a `T00:00:00` suffix to `start_date_local` *only* for WORKOUT category. NOTEs may require the same datetime format, or a different one.
+2. **Required `type` field** — for NOTE categories, intervals.icu may require a non-empty `type` field; the current payload omits it (`type omitempty`).
+3. **`name` requirement** — NOTEs may have different `name` / `description` semantics than WORKOUTs.
+4. **Less likely:** category enum casing (`NOTE` vs `Note` vs `note`) — verify against a working NOTE created via the intervals.icu web UI.
+
+This task requires **live API probing** against the `.env-dev` test athlete to isolate which of the above is the actual upstream contract.
+
+PRD anchors: §7.2.C event write field set; §7.4 schema-honesty rule.
+CLAUDE.md: hard rule 5 (terse-by-default — schemas matter); MCP-server conventions ("Schemas matter"); "Idempotency: writes that can be safely retried should be idempotent."
+
+Complexity: Blast radius 1 (one tool / one category branch), Pattern novelty 2 (new branch in date/required-field logic + live-probe loop), Security 1, Reversibility 2 (writes against real account but on dedicated test athlete) = 6 → Review Level 2. Size: M.
+
+## Dependencies
+
+- None. Independent of the other v0.2/v0.3 dogfood follow-ups (TP-072, TP-073, TP-074, TP-076, TP-077).
+- Useful prior art: TP-020 (event write cluster) shipped the WORKOUT branch — read its STATUS/PROMPT for the original payload design.
+
+## Context to Read First
+
+- [`docs/prd/PRD-icuvisor.md:256-`](../../docs/prd/PRD-icuvisor.md) — "Events & workouts" section. Note the `description` verbatim preservation rule.
+- [`docs/dogfood/v0.3-findings.md`](../../docs/dogfood/v0.3-findings.md) line 19 (W-01) and the per-tool triage row for `add_or_update_event`.
+- [`internal/tools/add_or_update_event.go`](../../internal/tools/add_or_update_event.go):
+  - Request struct: lines 26–40.
+  - Handler + date logic: lines 55–193.
+- [`internal/intervals/events.go`](../../internal/intervals/events.go):
+  - `AddOrUpdateEvent`: lines 131–151.
+  - `writeEventPayload`: lines 153–164.
+- [`internal/tools/add_or_update_event_test.go`](../../internal/tools/add_or_update_event_test.go) — existing WORKOUT round-trip test (lines 28–71). Mirror its pattern for the NOTE case.
+- Existing TP work: [`taskplane-tasks/TP-020-event-write-cluster/`](../TP-020-event-write-cluster/) for original design rationale.
+
+## File Scope
+
+- `internal/tools/add_or_update_event.go` — adjust the NOTE code path (date formatting + any missing required fields).
+- `internal/intervals/events.go` — extend `writeEventPayload` if a new required field needs to be carried.
+- `internal/tools/add_or_update_event_test.go` — add a NOTE round-trip test mirroring the WORKOUT one.
+- `internal/intervals/testdata/events/` — new fixture for NOTE create request/response.
+- `CHANGELOG.md` — `[Unreleased]` under "Fixed".
+- `STATUS.md` (this dir).
+
+Out of scope:
+- Refactoring the WORKOUT path.
+- Adding new event categories beyond NOTE (any further categories: separate task).
+- Touching delete or update flows beyond what's needed for the round-trip test cleanup.
+
+## Steps
+
+### Step 1: Live probe to isolate the upstream contract
+
+- [ ] Source `.env-dev` to get the test athlete credentials.
+- [ ] **Out-of-process probe** (use `curl` or a tiny Go scratch program — do NOT commit it): POST a minimal NOTE event directly to the intervals.icu events endpoint. Vary one field at a time:
+  - Minimal payload: `{ "start_date_local": "2026-05-25T00:00:00", "category": "NOTE", "name": "tp-075 probe a" }`.
+  - Without `T00:00:00`: `start_date_local: "2026-05-25"`.
+  - With `"type": ""` vs `"type": "Note"` vs omitting `type`.
+  - With/without `description`.
+- [ ] Record which combination is accepted. Save the request/response under `internal/intervals/testdata/events/note_create_request.json` + `note_create_response.json` (sanitize: redact athlete IDs, replace event IDs with `EVENT_ID_PLACEHOLDER`).
+- [ ] **Clean up:** delete every probe event you created on the test athlete (`gh` is fine for the issue; use the intervals.icu UI or the existing `delete_event` tool to remove the probe data). Verify with `get_events` that no probe events remain.
+
+### Step 2: Add a failing test
+
+- [ ] Mirror `TestAddOrUpdateEventCreatePreservesFreeTextTagsAndReadShape` (line 28) for the NOTE case, using the captured fixture as the expected outbound body.
+- [ ] Confirm the test fails on `main`.
+
+### Step 3: Fix the tool
+
+- [ ] Apply the minimum diff identified in Step 1. Likely candidates:
+  - Generalize the date suffix logic so all categories use ISO datetime, not just WORKOUT.
+  - Populate `type` with the upstream-required default for NOTEs if Step 1 confirmed that requirement.
+- [ ] Keep the WORKOUT path's existing semantics unchanged — assert by running the existing WORKOUT test.
+
+### Step 4: Build + lint + race + live re-validation
+
+- [ ] `make build`, `make test`, `make test-race`, `make lint`.
+- [ ] **Live re-validation** against `.env-dev`: call `add_or_update_event` via stdio MCP with a NOTE payload; confirm a new event appears in `get_events` for the chosen date; delete it; confirm it's gone.
+
+### Step 5: Document amendment
+
+- [ ] If Step 1 surfaced anything non-obvious about the upstream contract (e.g. `type` is required for NOTE but not WORKOUT, or vice versa), capture it in `docs/upstream-gaps/event-note-payload.md` (new file, 1–2 paragraphs). This is so future agents don't re-do the probe.
+
+### Step 6: Close the GitHub issue
+
+- [ ] Update `CHANGELOG.md` under `[Unreleased] → Fixed`: `add_or_update_event NOTE category create now succeeds against intervals.icu (was refused upstream due to <root cause>).`
+- [ ] Update `STATUS.md`.
+- [ ] Commit: `fix(events): repair add_or_update_event NOTE category create (TP-075, closes #6)`.
+- [ ] Reference `Closes #6` in the PR body. After merge, verify auto-close; otherwise `gh issue close 6 --comment "Fixed in <commit-sha> / <PR>"`.
+
+## Acceptance Criteria
+
+- A NOTE create via `add_or_update_event` against the test athlete is accepted upstream, and the resulting event appears in `get_events` for the chosen date.
+- The existing WORKOUT create path is unchanged (its test still passes).
+- A new unit test exercises the NOTE create round-trip using a fixture captured from the live probe.
+- `make build`, `make test`, `make test-race`, `make lint` pass.
+- Any probe-created events on the test athlete have been deleted; the test athlete is in the same state as before.
+- If a non-obvious upstream contract was discovered, `docs/upstream-gaps/event-note-payload.md` documents it.
+- GitHub issue #6 closed.
+
+## Do NOT
+
+- Do not commit your probe scratch files.
+- Do not leave probe-created events on the test athlete.
+- Do not paste raw request/response bodies into git without redacting athlete IDs / event IDs / dates that could identify the test account.
+- Do not introduce a `confirm: true` LLM-controlled override on this tool (CLAUDE.md hard rule 5).
+- Do not refactor the WORKOUT code path "while you're here" — separate concern.
+
+## Documentation
+
+- `CHANGELOG.md` `[Unreleased]` under "Fixed".
+- `STATUS.md` in this dir.
+- *Optional but encouraged:* `docs/upstream-gaps/event-note-payload.md`.
+
+## Git Commit Convention
+
+Conventional Commits, prefixed with TP-075. Example:
+
+```
+fix(events): repair add_or_update_event NOTE category create
+
+TP-075. Closes #6.
+```
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-075-add-or-update-event-note-create/STATUS.md
+++ b/taskplane-tasks/TP-075-add-or-update-event-note-create/STATUS.md
@@ -1,0 +1,31 @@
+# TP-075-add-or-update-event-note-create — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** M
+**Closes:** GitHub #6
+**Requires live API access:** YES (.env-dev test athlete)
+
+---
+
+### Step 1: Live probe to isolate the upstream contract
+**Status:** ⏳ Pending
+
+### Step 2: Add a failing test
+**Status:** ⏳ Pending
+
+### Step 3: Fix the tool
+**Status:** ⏳ Pending
+
+### Step 4: Build + lint + race + live re-validation
+**Status:** ⏳ Pending
+
+### Step 5: Document amendment
+**Status:** ⏳ Pending
+
+### Step 6: Close the GitHub issue
+**Status:** ⏳ Pending

--- a/taskplane-tasks/TP-077-create-workout-refused/PROMPT.md
+++ b/taskplane-tasks/TP-077-create-workout-refused/PROMPT.md
@@ -1,0 +1,133 @@
+# TP-077 — `create_workout` synthetic write refused
+
+## Mission
+
+Resolves [GitHub issue #9](https://github.com/ricardocabral/icuvisor/issues/9) — *TP-029: `create_workout` refused during dogfood*.
+
+During the v0.3 dogfood (TP-029, W-10 in [`docs/dogfood/v0.3-findings.md:28`](../../docs/dogfood/v0.3-findings.md)), an attempt to create a synthetic workout-library item against the dedicated test athlete failed: upstream refused the POST and `get_workout_library` re-read showed no top-level synthetic workout. Without a created workout, W-11 (`update_workout`) and the D-04 destructive case were both blocked.
+
+Suspected defects (from triage, ordered by likelihood — confirm via live probe):
+
+1. **Field name `type` vs `sport`** — [`internal/intervals/workout_library.go:208-230`](../../internal/intervals/workout_library.go) maps the tool's `sport` parameter to JSON key `"type"`. Upstream may expect `"sport"`, or it may expect `"type"` with values from a different enum than activity-type values.
+2. **`folder_id` requirement / format** — The test passed `folder_id: "f-20"` (synthetic) and the tool may require a real folder owned by the athlete, or it may require `null` for top-level workouts. Upstream may reject creates that reference a non-existent folder.
+3. **Hierarchy requirement** — Workout library writes may require the workout to be nested under an existing folder structure that the tool doesn't enforce.
+4. **Less likely:** `workout_doc` structured payload validation (if the request included structured steps, upstream may reject them on workout-library writes per the known mvilanova #56 — but the existing serializer should already handle this by reducing to the DSL description string).
+
+This task requires **live API probing** against the `.env-dev` test athlete to isolate the upstream contract.
+
+PRD anchors: §7.2.C workout-library CRUD; `workout_doc` description-string DSL serializer (v0.3, TP-019).
+CLAUDE.md: hard rule 5; MCP-server conventions ("Schemas matter").
+
+Complexity: Blast radius 1, Pattern novelty 2 (live probe + potentially a folder-seeding step), Security 1, Reversibility 2 (writes against dedicated test athlete) = 6 → Review Level 2. Size: M.
+
+## Dependencies
+
+- None hard. Independent of TP-072, TP-073, TP-074, TP-075, TP-076.
+- Useful prior art: [TP-023](../TP-023-workout-library-crud/) shipped the original CRUD path; [TP-019](../TP-019-workout-doc-serializer/) shipped the description-string DSL serializer that constrains the write-side `workout_doc` shape.
+
+## Context to Read First
+
+- [`docs/prd/PRD-icuvisor.md`](../../docs/prd/PRD-icuvisor.md) — workout-library CRUD section; `workout_doc` write-path serializer rule.
+- [`docs/dogfood/v0.3-findings.md`](../../docs/dogfood/v0.3-findings.md) line 28 (W-10) and per-tool triage row for `create_workout` / `update_workout`.
+- [`internal/tools/create_workout.go`](../../internal/tools/create_workout.go):
+  - Request struct: lines 26–33.
+  - Handler: lines 55–81.
+- [`internal/intervals/workout_library.go`](../../internal/intervals/workout_library.go):
+  - `CreateLibraryWorkout`: lines 126–137.
+  - `writeWorkoutBody`: lines 208–230. **This is where the suspected `type` vs `sport` mismatch lives.**
+- [`internal/tools/create_workout_test.go`](../../internal/tools/create_workout_test.go) — existing pattern.
+- Existing TP work: [`taskplane-tasks/TP-019-workout-doc-serializer/`](../TP-019-workout-doc-serializer/), [`taskplane-tasks/TP-023-workout-library-crud/`](../TP-023-workout-library-crud/).
+
+## File Scope
+
+- `internal/intervals/workout_library.go` — fix the field-name mapping in `writeWorkoutBody`.
+- `internal/tools/create_workout.go` — adjust validation if folder constraints surface (e.g. require non-empty `folder_id`, or accept `null` for top-level).
+- `internal/tools/create_workout_test.go` — update the existing test to match the corrected payload; add coverage for the folder-id permutation.
+- `internal/intervals/testdata/workout_library/` — fixture from the live probe.
+- `CHANGELOG.md` — `[Unreleased]` under "Fixed".
+- `STATUS.md` (this dir).
+
+Out of scope:
+- Refactoring `update_workout` / `delete_workout` — their tests are blocked until create works, but their implementations are separate.
+- Changing the `workout_doc` DSL serializer (TP-019 territory).
+- Adding new workout-library tool capabilities.
+
+## Steps
+
+### Step 1: Live probe to isolate the contract
+
+- [ ] Source `.env-dev`.
+- [ ] First, use `get_workout_library` against the test athlete to inventory existing folders. Capture a real folder ID you can write into (or confirm whether top-level writes work with no folder).
+- [ ] **Out-of-process probe** (curl / scratch Go — do NOT commit): POST a minimal workout create directly to the intervals.icu workout-library endpoint. Vary fields:
+  - `{ "name": "tp-077-probe", "type": "Ride", "folder_id": "<real-folder-id>" }`.
+  - Swap `"type"` for `"sport"`.
+  - Try `folder_id: null` for top-level.
+  - Try with `description` (the DSL string) included.
+- [ ] Note which permutation is accepted. Capture sanitized request/response under `internal/intervals/testdata/workout_library/create_request.json` + `create_response.json`.
+- [ ] **Clean up:** delete every probe-created workout (use the existing `delete_workout` tool in `full` delete mode, or the intervals.icu UI). Verify via `get_workout_library` that nothing extra remains.
+
+### Step 2: Add a failing test
+
+- [ ] Update `TestCreateWorkoutWithStructuredStepsSerializesDSLAndReturnsReadShape` (or add a new sibling test) so the expected outbound body matches the working payload from Step 1.
+- [ ] Confirm the test fails on `main`.
+
+### Step 3: Fix the client + tool
+
+- [ ] Apply the minimum diff in `writeWorkoutBody` (likely a JSON key rename).
+- [ ] If folder semantics changed: update the tool's input schema description for `folder_id` to make the contract explicit (`"folder_id: ID of an existing folder owned by the athlete; omit for top-level workouts"`).
+- [ ] If folder_id is required, add a clear public validation error when it's missing rather than letting the request fail upstream.
+
+### Step 4: Build + lint + race + live re-validation
+
+- [ ] `make build`, `make test`, `make test-race`, `make lint`.
+- [ ] Live re-validation via stdio MCP: `create_workout` → confirm via `get_workout_library` and `get_workouts_in_folder` that the new workout appears at the expected location; then `delete_workout` cleanup; confirm gone.
+
+### Step 5: Document amendment
+
+- [ ] If the upstream contract surfaced a non-obvious shape (e.g. `sport` vs `type` discrepancy with other endpoints), capture it in `docs/upstream-gaps/workout-library-create-payload.md`.
+
+### Step 6: Close the GitHub issue
+
+- [ ] Update `CHANGELOG.md` under `[Unreleased] → Fixed`: `create_workout now succeeds against intervals.icu (was refused upstream due to <root cause>).`
+- [ ] Update `STATUS.md`.
+- [ ] Commit: `fix(workouts): repair create_workout payload (TP-077, closes #9)`.
+- [ ] Reference `Closes #9` in the PR body. After merge, verify auto-close; otherwise `gh issue close 9 --comment "Fixed in <commit-sha> / <PR>"`.
+
+## Acceptance Criteria
+
+- A `create_workout` call against the test athlete is accepted upstream, and the new workout appears in `get_workout_library` / `get_workouts_in_folder` at the expected location.
+- The tool's input schema clearly documents the `folder_id` contract.
+- A new or updated unit test exercises the corrected payload using a captured fixture.
+- `make build`, `make test`, `make test-race`, `make lint` pass.
+- Probe-created workouts have been deleted from the test athlete.
+- GitHub issue #9 closed.
+
+## Do NOT
+
+- Do not commit probe scratch files.
+- Do not leave probe-created workouts on the test athlete.
+- Do not paste raw workout IDs / folder IDs / dates that could identify the test account without sanitization.
+- Do not introduce a `confirm: true` LLM-controlled override (CLAUDE.md hard rule 5).
+- Do not change the `workout_doc` description-DSL serializer — its read→modify→write round-trip is locked by golden-file tests (TP-019).
+
+## Documentation
+
+- `CHANGELOG.md` `[Unreleased]` under "Fixed".
+- `STATUS.md` in this dir.
+- *Optional:* `docs/upstream-gaps/workout-library-create-payload.md`.
+
+## Git Commit Convention
+
+Conventional Commits, prefixed with TP-077. Example:
+
+```
+fix(workouts): repair create_workout payload
+
+TP-077. Closes #9.
+```
+
+---
+
+## Amendments
+
+_Add amendments below this line only._

--- a/taskplane-tasks/TP-077-create-workout-refused/STATUS.md
+++ b/taskplane-tasks/TP-077-create-workout-refused/STATUS.md
@@ -1,0 +1,31 @@
+# TP-077-create-workout-refused — Status
+
+**Current Step:** Not started
+**Status:** ⏳ Open
+**Last Updated:** 2026-05-16
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** M
+**Closes:** GitHub #9
+**Requires live API access:** YES (.env-dev test athlete)
+
+---
+
+### Step 1: Live probe to isolate the contract
+**Status:** ⏳ Pending
+
+### Step 2: Add a failing test
+**Status:** ⏳ Pending
+
+### Step 3: Fix the client + tool
+**Status:** ⏳ Pending
+
+### Step 4: Build + lint + race + live re-validation
+**Status:** ⏳ Pending
+
+### Step 5: Document amendment
+**Status:** ⏳ Pending
+
+### Step 6: Close the GitHub issue
+**Status:** ⏳ Pending


### PR DESCRIPTION
## Summary
- add spO2, vo2max, abdomen, respiration, and menstrualPhase to update_wellness request/schema/client payloads
- validate the new fields and echo them in fields_updated
- add tests for sparse payloads, per-field writes, combined writes, and validation

Closes #8

## Tests
- make build
- make test
- make test-race
- make lint