### PR TITLE
feat(cli): add standalone agent-friendly CLI for `tools` 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,6 +302,7 @@ jobs:
           $out = "dist/icuvisor_${env:MSI_VERSION}_windows_${env:MATRIX_ARCH}.msi"
           New-Item -ItemType Directory -Force -Path dist | Out-Null
           $binary = (Resolve-Path "stage/extracted/icuvisor.exe").Path
+          $cliBinary = (Resolve-Path "stage/extracted/icuvisor-cli.exe").Path
           $license = (Resolve-Path "stage/extracted/LICENSE").Path
           $icon = (Resolve-Path "build/windows/icuvisor.ico").Path
           wix build `
@@ -309,6 +310,7 @@ jobs:
             -arch $env:MSI_ARCH `
             -d "Version=$env:MSI_VERSION" `
             -d "BinarySource=$binary" `
+            -d "CLIExecutableSource=$cliBinary" `
             -d "LicenseSource=$license" `
             -d "IconSource=$icon" `
             -o $out

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,16 +29,42 @@ builds:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
     goos: [darwin]
     goarch: [amd64, arm64]
+  - id: icuvisor-cli-linux-windows
+    main: ./cmd/icuvisor-cli
+    binary: icuvisor-cli
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+    goos: [linux, windows]
+    goarch: [amd64, arm64]
+  - id: icuvisor-cli-darwin
+    main: ./cmd/icuvisor-cli
+    binary: icuvisor-cli
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+    goos: [darwin]
+    goarch: [amd64, arm64]
 
 universal_binaries:
   - id: icuvisor-darwin-universal
     ids: [icuvisor-darwin]
     replace: true
     name_template: icuvisor
+  - id: icuvisor-cli-darwin-universal
+    ids: [icuvisor-cli-darwin]
+    replace: true
+    name_template: icuvisor-cli
 
 archives:
   - id: default
-    ids: [icuvisor-linux-windows]
+    ids: [icuvisor-linux-windows, icuvisor-cli-linux-windows]
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
     formats: [tar.gz]
@@ -50,7 +76,7 @@ archives:
       - README.md
       - CHANGELOG.md
   - id: darwin-universal
-    ids: [icuvisor-darwin-universal]
+    ids: [icuvisor-darwin-universal, icuvisor-cli-darwin-universal]
     name_template: "{{ .ProjectName }}_{{ .Version }}_macos_universal"
     formats: [tar.gz]
     files:
@@ -107,6 +133,7 @@ brews:
       token: "{{ .Env.HOMEBREW_TAP_PAT }}"
     install: |
       bin.install "icuvisor"
+      bin.install "icuvisor-cli"
     test: |
       assert_match version.to_s, shell_output("#{bin}/icuvisor version")
     caveats: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the tools-only `icuvisor-cli` contract with namespaced `tools list`, `tools describe`, and `tools call` commands, stdin argument support, compact progressive catalog discovery, canonical MCP descriptors, redacted `doctor` readiness, and machine-readable `capabilities`. MCP and direct calls now share local-athlete routing, registration gates, public-error sanitization, and per-call panic recovery; Resources and Prompts remain required follow-ups.
+
 ## [1.5.2] - 2026-07-15
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-BINARY := icuvisor
-PKG    := github.com/ricardocabral/icuvisor
+BINARY     := icuvisor
+CLI_BINARY := icuvisor-cli
+PKG        := github.com/ricardocabral/icuvisor
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS := -s -w -X main.version=$(VERSION)
 
@@ -19,14 +20,15 @@ HUGO_PORT  ?= 1313
 
 all: build ## Build the binary
 
-build: ## Build the binary into ./bin
+build: ## Build the MCP and standalone CLI binaries into ./bin
 	@mkdir -p bin
 	$(GO) build -trimpath -ldflags='$(LDFLAGS)' -o bin/$(BINARY) ./cmd/$(BINARY)
+	$(GO) build -trimpath -ldflags='$(LDFLAGS)' -o bin/$(CLI_BINARY) ./cmd/$(CLI_BINARY)
 
-install: ## Install the binary into $GOBIN
-	$(GO) install -trimpath -ldflags='$(LDFLAGS)' ./cmd/$(BINARY)
+install: ## Install the MCP and standalone CLI binaries into $GOBIN
+	$(GO) install -trimpath -ldflags='$(LDFLAGS)' ./cmd/$(BINARY) ./cmd/$(CLI_BINARY)
 
-run: ## Run the binary
+run: ## Run the MCP binary
 	$(GO) run ./cmd/$(BINARY)
 
 test: ## Run unit tests

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@
 
 The documentation covers local and hosted modes, privacy, safety modes, supported clients, troubleshooting, and the complete tool reference.
 
+## Direct CLI
+
+Releases also include `icuvisor-cli`, a tools-only command interface for local scripts and agents. It uses the same registered handlers and safety gates as MCP, loads credentials from local configuration or the OS keychain, and does not support coach mode.
+
+```bash
+icuvisor-cli capabilities
+icuvisor-cli doctor
+icuvisor-cli tools list
+icuvisor-cli tools describe get_today
+icuvisor-cli tools call get_today --args '{}'
+echo '{}' | icuvisor-cli tools call get_today --args-file -
+```
+
+Successful commands write JSON to stdout. Failures leave stdout empty and write one JSON error to stderr, using exit code `2` for usage errors and `1` for runtime errors. See the [CLI reference](https://icuvisor.app/reference/cli/) for the complete contract.
+
 ## For contributors
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and contribution guidelines. Product scope and planned work live in the [PRD](docs/prd/PRD-icuvisor.md) and [roadmap](ROADMAP.md).

--- a/build/macos/package_dmg.sh
+++ b/build/macos/package_dmg.sh
@@ -37,6 +37,7 @@ commit=${commit:-local}
 bundle_version=${ICUVISOR_BUNDLE_VERSION:-$commit}
 
 binary_path=${ICUVISOR_DARWIN_BINARY:-}
+cli_binary_path=${ICUVISOR_DARWIN_CLI_BINARY:-}
 if [[ -z "$binary_path" ]]; then
     while IFS= read -r candidate; do
         binary_path=$candidate
@@ -46,6 +47,16 @@ fi
 
 if [[ -z "$binary_path" || ! -f "$binary_path" ]]; then
     echo "error: universal darwin binary not found under $dist_dir" >&2
+    exit 1
+fi
+if [[ -z "$cli_binary_path" ]]; then
+    while IFS= read -r candidate; do
+        cli_binary_path=$candidate
+        break
+    done < <(find "$dist_dir" -path '*_darwin_all/icuvisor-cli' -type f | sort)
+fi
+if [[ -z "$cli_binary_path" || ! -f "$cli_binary_path" ]]; then
+    echo "error: universal standalone CLI binary not found under $dist_dir" >&2
     exit 1
 fi
 
@@ -79,7 +90,8 @@ Path(dst).write_text(text, encoding="utf-8")
 PY
 
 cp "$binary_path" "$app_path/Contents/MacOS/icuvisor"
-chmod 0755 "$app_path/Contents/MacOS/icuvisor"
+cp "$cli_binary_path" "$app_path/Contents/MacOS/icuvisor-cli"
+chmod 0755 "$app_path/Contents/MacOS/icuvisor" "$app_path/Contents/MacOS/icuvisor-cli"
 
 if [[ "$release_mode" == "1" ]]; then
     : "${APPLE_TEAM_ID:?APPLE_TEAM_ID is required for release packaging}"
@@ -101,6 +113,8 @@ if [[ "$release_mode" == "1" ]]; then
         exit 1
     fi
 
+    codesign --force --options runtime --timestamp --sign "$identity" "$app_path/Contents/MacOS/icuvisor"
+    codesign --force --options runtime --timestamp --sign "$identity" "$app_path/Contents/MacOS/icuvisor-cli"
     codesign --force --options runtime --timestamp --sign "$identity" "$app_path"
     codesign --verify --deep --strict --verbose=2 "$app_path"
 else

--- a/build/windows/icuvisor.wxs
+++ b/build/windows/icuvisor.wxs
@@ -9,6 +9,7 @@
   Variables are passed by the CI build at `wix build` time:
     -d Version=<x.y.z>         (no leading "v"; max N.N.N.N MSI version)
     -d BinarySource=<path>     path to icuvisor.exe
+    -d CLIExecutableSource=<path> path to icuvisor-cli.exe
     -d LicenseSource=<path>    path to LICENSE
     -d IconSource=<path>       path to icuvisor.ico
 
@@ -24,7 +25,7 @@
       Scope="perUser"
       Compressed="yes">
 
-    <SummaryInformation Description="icuvisor MCP server installer" />
+    <SummaryInformation Description="icuvisor MCP server and CLI installer" />
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of icuvisor is already installed." />
 
@@ -51,6 +52,10 @@
             Part="first"
             System="no"
             Value="[INSTALLFOLDER]" />
+      </Component>
+
+      <Component Id="IcuvisorCLIExe" Directory="INSTALLFOLDER" Guid="*">
+        <File Id="icuvisor-cli.exe" Source="$(var.CLIExecutableSource)" KeyPath="yes" />
       </Component>
 
       <Component Id="LicenseFile" Directory="INSTALLFOLDER" Guid="*">

--- a/cmd/icuvisor-cli/main.go
+++ b/cmd/icuvisor-cli/main.go
@@ -1,0 +1,22 @@
+// Package main is the entrypoint for the standalone icuvisor CLI.
+package main
+
+import (
+	"context"
+	"os"
+	_ "time/tzdata"
+
+	"github.com/ricardocabral/icuvisor/internal/cli"
+)
+
+// version is set at build time via -ldflags "-X main.version=...".
+var version = "dev"
+
+func main() {
+	os.Exit(cli.RunCLI(context.Background(), cli.Options{
+		Version: version,
+		Args:    os.Args[1:],
+		Stdout:  os.Stdout,
+		Stderr:  os.Stderr,
+	}))
+}

--- a/docs/internal/core-library.md
+++ b/docs/internal/core-library.md
@@ -30,6 +30,7 @@ The facade intentionally exposes a narrow host-safe surface:
   - `NewPromptRegistry()`.
   - `NewServer(context.Context, ServerOptions)`.
   - `Server.CatalogHash()`, `Run`, `ServeStreamableHTTP`, and `RunStreamableHTTP`.
+  - `NewInvoker(context.Context, InvokerOptions)`, `Invoker.Tools()`, and `Invoker.Invoke()` for a non-MCP local view over the same safety-gated core catalog.
   - `RecentToolCallRecorder` for host or CLI diagnostics that record tool names without exposing arguments or payloads.
 - Catalog helpers:
   - `CollectToolCatalog(context.Context, CatalogOptions)`.
@@ -46,7 +47,7 @@ The public types are not aliases of `internal/...` types. Callers should treat t
 
 ## Public CLI adoption
 
-The local `icuvisor` CLI's default non-coach MCP startup path now constructs the Intervals API-key client, core tool registry, resource registry, prompt registry, and MCP server through `pkg/icuvisor`. This keeps the public facade exercised by production CLI behavior instead of only by host-side tests.
+The local `icuvisor` MCP binary and `icuvisor-cli` standalone direct-tool binary both construct the Intervals API-key client and core tool registry through `pkg/icuvisor`. The standalone view invokes registry handlers through `Invoker` rather than serializing an MCP request, while preserving the configured toolset and registration-time delete/write policy. This keeps the public facade exercised by both production views instead of only by host-side tests.
 
 Coach mode remains on the existing internal wiring path for now because it still depends on internal selection-store and coach ACL machinery that is not part of the public host-safe contract. The public facade is covered by parity tests against the internal registries for catalog hashes/tool names, resources, prompts, delete-mode/toolset combinations, and API-key Basic Auth behavior.
 
@@ -86,5 +87,5 @@ The facade owns several safety behaviors required by stateless hosted MCP server
 Targeted verification for changes to this boundary:
 
 ```sh
-go test ./internal/athleteprofile ./internal/resources ./internal/intervals ./internal/tools ./internal/mcp ./pkg/icuvisor
+go test ./internal/athleteprofile ./internal/resources ./internal/intervals ./internal/tools ./internal/toolexec ./internal/cli ./internal/mcp ./pkg/icuvisor
 ```

--- a/internal/cli/standalone.go
+++ b/internal/cli/standalone.go
@@ -1,0 +1,478 @@
+// Package cli implements the standalone command-line view over icuvisor core tools.
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/ricardocabral/icuvisor/internal/config"
+	"github.com/ricardocabral/icuvisor/internal/credstore"
+	core "github.com/ricardocabral/icuvisor/pkg/icuvisor"
+)
+
+const cliContractVersion = "1"
+
+// Options configures the standalone CLI process.
+type Options struct {
+	Version string
+	Args    []string
+	Stdin   io.Reader
+	Stdout  io.Writer
+	Stderr  io.Writer
+
+	LoadConfig func(context.Context, config.Options) (config.Config, error)
+	NewClient  func(core.APIKeyClientOptions) (*core.Client, error)
+	NewInvoker func(context.Context, core.InvokerOptions) (*core.Invoker, error)
+}
+
+type usageError struct{ message string }
+
+func (e *usageError) Error() string { return e.message }
+
+func usage(message string, args ...any) error {
+	return &usageError{message: fmt.Sprintf(message, args...)}
+}
+
+// RunCLI runs the standalone CLI and returns a process exit code.
+func RunCLI(ctx context.Context, opts Options) int {
+	err := Run(ctx, opts)
+	if err == nil {
+		return 0
+	}
+	code := 1
+	var invalidUsage *usageError
+	if errors.As(err, &invalidUsage) {
+		code = 2
+	}
+	stderr := opts.Stderr
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	_ = json.NewEncoder(stderr).Encode(map[string]any{"error": err.Error(), "exit_code": code})
+	return code
+}
+
+// Run runs the standalone CLI.
+func Run(ctx context.Context, opts Options) error {
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	version := normalizedVersion(opts.Version)
+	if len(opts.Args) == 0 || isHelp(opts.Args) {
+		return writeHelp(stdout)
+	}
+	if opts.Args[0] == "version" {
+		if len(opts.Args) != 1 {
+			return usage("version does not accept arguments")
+		}
+		_, err := fmt.Fprintln(stdout, version)
+		return err
+	}
+
+	switch opts.Args[0] {
+	case "tools":
+		return runTools(ctx, opts, stdout, opts.Args[1:])
+	case "doctor":
+		return runDoctor(ctx, opts, stdout, opts.Args[1:])
+	case "capabilities":
+		return runCapabilities(ctx, opts, stdout, opts.Args[1:])
+	default:
+		return usage("unknown command %q; use tools, doctor, capabilities, version, or help", opts.Args[0])
+	}
+}
+
+func runTools(ctx context.Context, opts Options, stdout io.Writer, args []string) error {
+	if len(args) == 0 {
+		return usage("tools requires a subcommand: list, describe, or call")
+	}
+	switch args[0] {
+	case "list":
+		invoker, err := newInvoker(ctx, opts, args[1:])
+		if err != nil {
+			return err
+		}
+		entries := make([]toolListEntry, 0, len(invoker.Tools()))
+		for _, tool := range invoker.Tools() {
+			entries = append(entries, toolListEntry{Name: tool.Name, Summary: shortSummary(tool.Description), Toolset: tool.Toolset, Safety: tool.Requirement})
+		}
+		return writeJSON(stdout, toolList{Header: invoker.Info(), Tools: entries})
+	case "describe":
+		toolName, runtimeArgs, err := splitToolName(args[1:], "tools describe")
+		if err != nil {
+			return err
+		}
+		invoker, err := newInvoker(ctx, opts, runtimeArgs)
+		if err != nil {
+			return err
+		}
+		for _, tool := range invoker.Tools() {
+			if tool.Name == toolName {
+				return writeJSON(stdout, tool)
+			}
+		}
+		return fmt.Errorf("unknown or unavailable tool %q", toolName)
+	case "call":
+		toolName, runtimeArgs, err := splitToolName(args[1:], "tools call")
+		if err != nil {
+			return err
+		}
+		request, configOpts, err := parseCallArgs(runtimeArgs, stdinOrDefault(opts.Stdin))
+		if err != nil {
+			return err
+		}
+		invoker, err := loadInvoker(ctx, opts, configOpts)
+		if err != nil {
+			return err
+		}
+		result, err := invoker.Invoke(ctx, toolName, request)
+		if err != nil {
+			return err
+		}
+		if result.IsError {
+			return fmt.Errorf("calling %s: %s", toolName, resultErrorMessage(result))
+		}
+		return writeJSON(stdout, result.StructuredContent)
+	default:
+		return usage("unknown tools subcommand %q; use list, describe, or call", args[0])
+	}
+}
+
+type toolList struct {
+	Header core.InvokerInfo `json:"header"`
+	Tools  []toolListEntry  `json:"tools"`
+}
+
+type toolListEntry struct {
+	Name    string           `json:"name"`
+	Summary string           `json:"summary"`
+	Toolset core.Toolset     `json:"toolset"`
+	Safety  core.Requirement `json:"safety"`
+}
+
+func runCapabilities(ctx context.Context, opts Options, stdout io.Writer, args []string) error {
+	invoker, err := newInvoker(ctx, opts, args)
+	if err != nil {
+		return err
+	}
+	return writeJSON(stdout, map[string]any{
+		"cli_contract_version": cliContractVersion,
+		"icuvisor_version":     invoker.Info().Version,
+		"catalog_hash":         invoker.Info().CatalogHash,
+		"active_gates": map[string]any{
+			"toolset":     invoker.Info().Toolset,
+			"delete_mode": invoker.Info().DeleteMode,
+		},
+		"surfaces": map[string]any{
+			"tools":     true,
+			"resources": false,
+			"prompts":   false,
+		},
+		"coach_mode": map[string]any{"supported": false},
+	})
+}
+
+func runDoctor(ctx context.Context, opts Options, stdout io.Writer, args []string) error {
+	invoker, err := newInvoker(ctx, opts, args)
+	if err != nil {
+		return err
+	}
+	reachability := "ok"
+	ready := true
+	result, callErr := invoker.Invoke(ctx, "get_athlete_profile", json.RawMessage(`{}`))
+	if callErr != nil || result.IsError {
+		reachability = "failed"
+		ready = false
+	}
+	return writeJSON(stdout, map[string]any{
+		"ready": ready,
+		"checks": map[string]string{
+			"config":         "ok",
+			"authentication": "configured",
+			"reachability":   reachability,
+		},
+	})
+}
+
+func newInvoker(ctx context.Context, opts Options, args []string) (*core.Invoker, error) {
+	configOpts, err := parseRuntimeArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	return loadInvoker(ctx, opts, configOpts)
+}
+
+func loadInvoker(ctx context.Context, opts Options, configOpts config.Options) (*core.Invoker, error) {
+	if configOpts.CredentialStore == nil {
+		configOpts.CredentialStore = credstore.OSKeychain()
+	}
+	configOpts.Path = defaultConfigPath(configOpts.Path)
+	loader := opts.LoadConfig
+	if loader == nil {
+		loader = loadConfigQuietly
+	}
+	cfg, err := loader(ctx, configOpts)
+	if err != nil {
+		return nil, errors.New("loading configuration failed; check icuvisor setup and local config")
+	}
+	if cfg.CoachModeEnabled() {
+		return nil, errors.New("standalone CLI does not support coach mode; use the MCP server")
+	}
+	coreConfig := coreConfigFromInternal(cfg)
+	newClient := opts.NewClient
+	if newClient == nil {
+		newClient = core.NewAPIKeyClient
+	}
+	client, err := newClient(core.APIKeyClientOptions{Config: coreConfig, Version: opts.Version})
+	if err != nil {
+		return nil, errors.New("creating intervals client failed; check local configuration")
+	}
+	registry := core.NewCoreRegistry(client, core.RegistryOptions{
+		Config:           coreConfig,
+		Version:          opts.Version,
+		TimezoneFallback: cfg.Timezone,
+		DebugMetadata:    cfg.DebugMetadata,
+		DeleteMode:       core.DeleteMode(cfg.DeleteMode.String()),
+		Toolset:          core.Toolset(cfg.Toolset.String()),
+	})
+	newInvoker := opts.NewInvoker
+	if newInvoker == nil {
+		newInvoker = core.NewInvoker
+	}
+	invoker, err := newInvoker(ctx, core.InvokerOptions{
+		Config:     coreConfig,
+		Registry:   registry,
+		Version:    normalizedVersion(opts.Version),
+		DeleteMode: core.DeleteMode(cfg.DeleteMode.String()),
+		Toolset:    core.Toolset(cfg.Toolset.String()),
+	})
+	if err != nil {
+		return nil, errors.New("creating direct tool invoker failed; check local configuration")
+	}
+	return invoker, nil
+}
+
+func loadConfigQuietly(ctx context.Context, opts config.Options) (config.Config, error) {
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	defer slog.SetDefault(previous)
+	return config.Load(ctx, opts)
+}
+
+func coreConfigFromInternal(cfg config.Config) core.Config {
+	return core.Config{APIKey: cfg.APIKey, AthleteID: cfg.AthleteID, Timezone: cfg.Timezone, APIBaseURL: cfg.APIBaseURL, HTTPTimeout: cfg.HTTPTimeout, DeleteMode: core.DeleteMode(cfg.DeleteMode.String()), Toolset: core.Toolset(cfg.Toolset.String()), DebugMetadata: cfg.DebugMetadata}
+}
+
+func resultErrorMessage(result core.ToolResult) string {
+	for _, item := range result.Content {
+		if strings.TrimSpace(item.Text) != "" {
+			return item.Text
+		}
+	}
+	return "tool returned an error result"
+}
+
+func splitToolName(args []string, command string) (string, []string, error) {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return "", nil, usage("%s requires a tool name", command)
+	}
+	return args[0], args[1:], nil
+}
+
+func parseCallArgs(args []string, stdin io.Reader) (json.RawMessage, config.Options, error) {
+	var request json.RawMessage
+	argumentSource := ""
+	filtered := make([]string, 0, len(args))
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch arg {
+		case "--args":
+			if argumentSource != "" {
+				return nil, config.Options{}, usage("use only one of --args or --args-file")
+			}
+			value, next, err := flagValue(args, index, "--args")
+			if err != nil {
+				return nil, config.Options{}, err
+			}
+			request = json.RawMessage(value)
+			argumentSource = "--args"
+			index = next
+		case "--args-file":
+			if argumentSource != "" {
+				return nil, config.Options{}, usage("use only one of --args or --args-file")
+			}
+			path, next, err := flagValue(args, index, "--args-file")
+			if err != nil {
+				return nil, config.Options{}, err
+			}
+			var body []byte
+			if path == "-" {
+				body, err = io.ReadAll(stdin)
+			} else {
+				body, err = os.ReadFile(path)
+			}
+			if err != nil {
+				return nil, config.Options{}, fmt.Errorf("reading --args-file: %w", err)
+			}
+			request = body
+			argumentSource = "--args-file"
+			index = next
+		default:
+			filtered = append(filtered, arg)
+		}
+	}
+	if request == nil {
+		request = json.RawMessage(`{}`)
+	}
+	if !json.Valid(request) {
+		return nil, config.Options{}, usage("tool arguments must be valid JSON")
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(request, &object); err != nil || object == nil {
+		return nil, config.Options{}, usage("tool arguments must be a JSON object")
+	}
+	configOpts, err := parseRuntimeArgs(filtered)
+	return request, configOpts, err
+}
+
+func parseRuntimeArgs(args []string) (config.Options, error) {
+	var opts config.Options
+	for index := 0; index < len(args); index++ {
+		switch args[index] {
+		case "--config":
+			value, next, err := flagValue(args, index, "--config")
+			if err != nil {
+				return config.Options{}, err
+			}
+			opts.Path = value
+			index = next
+		case "--env-file":
+			value, next, err := flagValue(args, index, "--env-file")
+			if err != nil {
+				return config.Options{}, err
+			}
+			opts.DotEnvPath = value
+			opts.DotEnvExplicit = true
+			index = next
+		default:
+			return config.Options{}, usage("unknown flag %q", args[index])
+		}
+	}
+	return opts, nil
+}
+
+func flagValue(args []string, index int, name string) (string, int, error) {
+	next := index + 1
+	if next >= len(args) || strings.TrimSpace(args[next]) == "" || strings.HasPrefix(args[next], "--") {
+		return "", index, usage("missing value for %s", name)
+	}
+	return args[next], next, nil
+}
+
+func defaultConfigPath(path string) string {
+	if strings.TrimSpace(path) != "" || strings.TrimSpace(os.Getenv(config.EnvConfigPath)) != "" {
+		return path
+	}
+	defaultPath, err := config.DefaultPath()
+	if err != nil {
+		return path
+	}
+	if _, err := os.Stat(defaultPath); err == nil {
+		return defaultPath
+	}
+	return path
+}
+
+func isHelp(args []string) bool {
+	if len(args) > 0 && args[0] == "help" {
+		return true
+	}
+	for _, arg := range args {
+		if arg == "--help" || arg == "-h" {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizedVersion(version string) string {
+	if version = strings.TrimSpace(version); version != "" {
+		return version
+	}
+	return "dev"
+}
+
+func stdinOrDefault(r io.Reader) io.Reader {
+	if r != nil {
+		return r
+	}
+	return os.Stdin
+}
+
+func shortSummary(description string) string {
+	description = strings.TrimSpace(description)
+	if end := strings.Index(description, ". "); end >= 0 {
+		description = description[:end+1]
+	}
+	const max = 180
+	if len(description) > max {
+		description = strings.TrimSpace(description[:max-3]) + "..."
+	}
+	return description
+}
+
+func writeJSON(w io.Writer, value any) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		return fmt.Errorf("writing JSON: %w", err)
+	}
+	return nil
+}
+
+func writeHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Invoke icuvisor tools directly without an MCP transport.
+
+Usage:
+  icuvisor-cli tools list [runtime flags]
+  icuvisor-cli tools describe <tool> [runtime flags]
+  icuvisor-cli tools call <tool> [--args <json> | --args-file <path> | --args-file -] [runtime flags]
+  icuvisor-cli doctor [runtime flags]
+  icuvisor-cli capabilities [runtime flags]
+  icuvisor-cli version
+
+Commands:
+  tools list       Print a compact tool catalog and active-policy header.
+  tools describe   Print one canonical MCP tool descriptor.
+  tools call       Invoke one tool and print its structured result.
+  doctor           Check redacted config, authentication, and reachability readiness.
+  capabilities     Print the CLI contract, supported surfaces, and active gates.
+  version          Print the icuvisor-cli version.
+
+Runtime flags:
+  --config <path>    JSON config file path. Can also be set with ICUVISOR_CONFIG.
+  --env-file <path>  Env-file path to load before process env. Can also be set with ICUVISOR_ENV_FILE.
+
+Argument flags:
+  --args <json>       JSON object passed to the tool. Defaults to {}.
+  --args-file <path>  File containing the JSON object passed to the tool.
+  --args-file -       Read the JSON object from stdin.
+
+Process contract:
+  Success writes JSON to stdout only. Failures leave stdout empty and write one JSON error to stderr.
+  Exit codes: 0 success, 2 usage error, 1 runtime error.
+  Output is deterministic, non-interactive, and contains no ANSI formatting.
+  The standalone CLI uses the configured local athlete only; coach mode remains MCP-only.
+  API keys are loaded from configuration or the OS keychain and are never flags or tool arguments.
+`)
+	if err != nil {
+		return fmt.Errorf("writing help: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/standalone_test.go
+++ b/internal/cli/standalone_test.go
@@ -1,0 +1,203 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ricardocabral/icuvisor/internal/coach"
+	"github.com/ricardocabral/icuvisor/internal/config"
+	"github.com/ricardocabral/icuvisor/internal/safety"
+)
+
+func TestRunToolsListIsCompactAndCarriesHeader(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	err := Run(context.Background(), Options{Args: []string{"tools", "list"}, Stdout: &stdout, Version: "vtest", LoadConfig: testLoadConfig})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	var parsed struct {
+		Header struct {
+			Version     string `json:"version"`
+			Toolset     string `json:"toolset"`
+			DeleteMode  string `json:"delete_mode"`
+			CatalogHash string `json:"catalog_hash"`
+		} `json:"header"`
+		Tools []map[string]any `json:"tools"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &parsed); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if parsed.Header.Version != "vtest" || parsed.Header.Toolset != "core" || parsed.Header.DeleteMode != "safe" || parsed.Header.CatalogHash == "" {
+		t.Fatalf("header = %#v", parsed.Header)
+	}
+	if len(parsed.Tools) == 0 {
+		t.Fatal("tools list is empty")
+	}
+	for _, entry := range parsed.Tools {
+		if entry["name"] == "get_athlete_profile" {
+			if entry["summary"] == nil || entry["toolset"] != "core" || entry["safety"] != "read" {
+				t.Fatalf("profile entry = %#v", entry)
+			}
+			if entry["inputSchema"] != nil || entry["outputSchema"] != nil {
+				t.Fatalf("compact entry leaked schemas: %#v", entry)
+			}
+			return
+		}
+	}
+	t.Fatal("list output missing get_athlete_profile")
+}
+
+func TestRunToolsDescribeUsesCanonicalMCPFields(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	err := Run(context.Background(), Options{Args: []string{"tools", "describe", "get_athlete_profile"}, Stdout: &stdout, Version: "vtest", LoadConfig: testLoadConfig})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &parsed); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	for _, key := range []string{"name", "description", "inputSchema", "outputSchema", "annotations", "_meta"} {
+		if _, ok := parsed[key]; !ok {
+			t.Fatalf("describe output missing %s: %s", key, stdout.Bytes())
+		}
+	}
+	if parsed["input_schema"] != nil || parsed["output_schema"] != nil {
+		t.Fatalf("describe output uses legacy snake_case fields: %s", stdout.Bytes())
+	}
+	meta := parsed["_meta"].(map[string]any)["icuvisor"].(map[string]any)
+	if meta["toolset"] != "core" || meta["safety"] != "read" {
+		t.Fatalf("_meta.icuvisor = %#v", meta)
+	}
+}
+
+func TestRunToolsCallWritesStructuredJSON(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	err := Run(context.Background(), Options{Args: []string{"tools", "call", "icuvisor_check_server_version"}, Stdout: &stdout, Version: "vtest", LoadConfig: testLoadConfig})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte(`"description_server_version": "vtest"`)) {
+		t.Fatalf("call output = %s", stdout.Bytes())
+	}
+	if bytes.Contains(stdout.Bytes(), []byte(`structuredContent`)) {
+		t.Fatalf("call output contains MCP envelope: %s", stdout.Bytes())
+	}
+}
+
+func TestParseCallArgsReadsStdin(t *testing.T) {
+	t.Parallel()
+
+	request, _, err := parseCallArgs([]string{"--args-file", "-"}, strings.NewReader(`{"include_full":true}`))
+	if err != nil {
+		t.Fatalf("parseCallArgs() error = %v", err)
+	}
+	if string(request) != `{"include_full":true}` {
+		t.Fatalf("request = %s", request)
+	}
+}
+
+func TestParseCallArgsRejectsMultipleArgumentSources(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := parseCallArgs([]string{"--args", `{}`, "--args-file", "request.json"}, strings.NewReader(""))
+	if err == nil || !strings.Contains(err.Error(), "only one") {
+		t.Fatalf("parseCallArgs() error = %v, want mutually-exclusive argument-source error", err)
+	}
+}
+
+func TestRunCLIUsageFailureWritesOnlyMachineError(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := RunCLI(context.Background(), Options{Args: []string{"tools", "call", "get_athlete_profile", "--args", `[]`}, Stdout: &stdout, Stderr: &stderr, LoadConfig: testLoadConfig})
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if bytes.Count(stderr.Bytes(), []byte("\n")) != 1 {
+		t.Fatalf("stderr = %q, want one line", stderr.String())
+	}
+	var failure struct {
+		Error    string `json:"error"`
+		ExitCode int    `json:"exit_code"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &failure); err != nil || failure.ExitCode != 2 || !strings.Contains(failure.Error, "JSON object") {
+		t.Fatalf("failure = %#v, unmarshal error = %v", failure, err)
+	}
+}
+
+func TestRunCLIDoesNotTreatArgumentValueHelpAsHelp(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := RunCLI(context.Background(), Options{
+		Args:       []string{"tools", "call", "icuvisor_check_server_version", "--args", "help"},
+		Stdout:     &stdout,
+		Stderr:     &stderr,
+		LoadConfig: testLoadConfig,
+	})
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	var failure struct {
+		Error    string `json:"error"`
+		ExitCode int    `json:"exit_code"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &failure); err != nil || failure.ExitCode != 2 || failure.Error == "" {
+		t.Fatalf("failure = %#v, unmarshal error = %v", failure, err)
+	}
+}
+
+func TestRunCapabilitiesReportsToolsOnlyContract(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	if err := Run(context.Background(), Options{Args: []string{"capabilities"}, Stdout: &stdout, Version: "vtest", LoadConfig: testLoadConfig}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &parsed); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if parsed["cli_contract_version"] != cliContractVersion || parsed["catalog_hash"] == "" {
+		t.Fatalf("capabilities = %#v", parsed)
+	}
+	surfaces := parsed["surfaces"].(map[string]any)
+	if surfaces["tools"] != true || surfaces["resources"] != false || surfaces["prompts"] != false {
+		t.Fatalf("surfaces = %#v", surfaces)
+	}
+}
+
+func TestRunRefusesEffectiveCoachMode(t *testing.T) {
+	t.Parallel()
+
+	loader := func(context.Context, config.Options) (config.Config, error) {
+		cfg, _ := testLoadConfig(context.Background(), config.Options{})
+		cfg.CoachMode = coach.ModeOn
+		return cfg, nil
+	}
+	err := Run(context.Background(), Options{Args: []string{"tools", "list"}, LoadConfig: loader})
+	if err == nil || !strings.Contains(err.Error(), "does not support coach mode") {
+		t.Fatalf("Run() error = %v", err)
+	}
+}
+
+func testLoadConfig(context.Context, config.Options) (config.Config, error) {
+	return config.Config{APIKey: "test-api-key", AthleteID: "i12345", Timezone: "UTC", APIBaseURL: config.DefaultAPIBaseURL, HTTPTimeout: time.Second, DeleteMode: safety.ModeSafe, Toolset: safety.ToolsetCore}, nil
+}

--- a/internal/mcp/protocol_test.go
+++ b/internal/mcp/protocol_test.go
@@ -320,6 +320,18 @@ func TestProtocolSharedTransportSuite(t *testing.T) {
 			},
 		},
 		{
+			name: "tool_call_panic_is_sanitized",
+			opts: Options{Registry: panickingToolRegistry()},
+			run: func(t *testing.T, ctx context.Context, session *sdkmcp.ClientSession) {
+				t.Helper()
+				result, err := session.CallTool(ctx, &sdkmcp.CallToolParams{Name: "test_panic", Arguments: map[string]any{}})
+				if err != nil {
+					t.Fatalf("CallTool(test_panic) protocol error = %v", err)
+				}
+				assertSanitizedToolError(t, result)
+			},
+		},
+		{
 			name: "resources_list_and_read",
 			opts: Options{ResourceRegistry: testResourceRegistry{}},
 			run: func(t *testing.T, ctx context.Context, session *sdkmcp.ClientSession) {
@@ -2025,6 +2037,20 @@ func failingToolRegistry() tools.Registry {
 			Toolset:     safety.ToolsetCore,
 			Handler: func(context.Context, tools.Request) (tools.Result, error) {
 				return tools.Result{}, errors.New("secret upstream stack detail")
+			},
+		})
+	})
+}
+
+func panickingToolRegistry() tools.Registry {
+	return registryFunc(func(_ context.Context, registrar tools.Registrar) error {
+		return registrar.AddTool(tools.Tool{
+			Name:        "test_panic",
+			Description: "Panics for execution-boundary recovery tests.",
+			InputSchema: map[string]any{"type": "object"},
+			Toolset:     safety.ToolsetCore,
+			Handler: func(context.Context, tools.Request) (tools.Result, error) {
+				panic("secret panic detail")
 			},
 		})
 	})

--- a/internal/mcp/registrar_tools.go
+++ b/internal/mcp/registrar_tools.go
@@ -16,12 +16,13 @@ import (
 	"github.com/ricardocabral/icuvisor/internal/intervals"
 	"github.com/ricardocabral/icuvisor/internal/safety"
 	"github.com/ricardocabral/icuvisor/internal/toolcatalog"
+	"github.com/ricardocabral/icuvisor/internal/toolexec"
 	"github.com/ricardocabral/icuvisor/internal/tools"
 )
 
-const genericToolErrorMessage = "tool failed; try again or check icuvisor logs"
+const genericToolErrorMessage = toolexec.GenericErrorMessage
 
-const invalidInputToolErrorMessage = "invalid tool arguments; check the inputs and try again"
+const invalidInputToolErrorMessage = toolexec.InvalidInputErrorMessage
 
 const invalidTargetAthleteFormatMessage = "invalid athlete_id; use format i12345 or 12345"
 
@@ -29,7 +30,7 @@ const unauthorizedTargetAthleteMessage = "athlete_id is not authorized for this 
 
 const toolNotAllowedForAthleteMessage = "tool is not allowed for the selected athlete"
 
-const localModeAthleteTargetMessage = "athlete_id is only supported when coach mode is enabled"
+const localModeAthleteTargetMessage = toolexec.LocalModeAthleteTargetMessage
 
 func capabilityOrSafe(capability safety.Capability) safety.Capability {
 	if capability != nil {
@@ -64,7 +65,8 @@ type safeRegistrar struct {
 	recentToolCalls        diagnostics.RecentToolCallRecorder
 }
 
-func sdkToolAnnotations(tool tools.Tool) *sdkmcp.ToolAnnotations {
+// SDKToolAnnotations returns the canonical MCP annotations for a tool descriptor.
+func SDKToolAnnotations(tool tools.Tool) *sdkmcp.ToolAnnotations {
 	if tool.RequiresWrite() {
 		return nil
 	}
@@ -109,7 +111,7 @@ func (r *safeRegistrar) AddTool(tool tools.Tool) error {
 			Description:  tool.Description,
 			InputSchema:  tool.InputSchema,
 			OutputSchema: tool.OutputSchema,
-			Annotations:  sdkToolAnnotations(tool),
+			Annotations:  SDKToolAnnotations(tool),
 		}, func(ctx context.Context, req *sdkmcp.CallToolRequest) (res *sdkmcp.CallToolResult, err error) {
 			started := time.Now()
 			argumentBytes := len(req.Params.Arguments)
@@ -131,17 +133,21 @@ func (r *safeRegistrar) AddTool(tool tools.Tool) error {
 				res = toolErrorResult(publicToolErrorMessage(err))
 				return res, nil
 			}
-			result, err := tool.Handler(callCtx, tools.Request{
+			localAthleteID := ""
+			if !r.config.CoachModeEnabled() {
+				localAthleteID = r.config.AthleteID
+			}
+			outcome := toolexec.Execute(callCtx, tool, tools.Request{
 				Name:      req.Params.Name,
 				Arguments: arguments,
-			})
-			if err != nil {
+			}, localAthleteID)
+			if outcome.Err != nil {
 				status = "tool_error"
-				logToolHandlerError(r.logger, tool.Name, err)
-				res = toolErrorResult(publicToolErrorMessage(err))
+				logToolHandlerError(r.logger, tool.Name, outcome.Err)
+				res = toolErrorResult(outcome.PublicMessage)
 				return res, nil
 			}
-			converted, err := convertResult(result)
+			converted, err := convertResult(outcome.Result)
 			if err != nil {
 				status = "conversion_error"
 				r.logger.Error("tool result conversion failed", "tool", tool.Name, "error", err)
@@ -228,15 +234,12 @@ func (r *safeRegistrar) resolveToolTarget(ctx context.Context, toolName string, 
 	if !toolcatalog.IsAthleteScopedTool(toolName) {
 		return ctx, raw, nil
 	}
-	arguments, suppliedAthleteID, suppliedAthleteIDPresent, err := stripAthleteID(raw)
+	arguments, suppliedAthleteID, _, err := stripAthleteID(raw)
 	if err != nil {
 		return ctx, nil, tools.NewUserError(invalidTargetAthleteFormatMessage, err)
 	}
 	if !r.config.CoachModeEnabled() {
-		if suppliedAthleteIDPresent {
-			return ctx, nil, tools.NewUserError(localModeAthleteTargetMessage, nil)
-		}
-		return intervals.WithTargetAthleteID(ctx, r.config.AthleteID), raw, nil
+		return ctx, raw, nil
 	}
 	targetAthleteID, err := r.resolveAthleteID(ctx, toolName, suppliedAthleteID)
 	if err != nil {
@@ -271,26 +274,11 @@ func (r *safeRegistrar) selectedAthleteID(ctx context.Context) string {
 }
 
 func (r *safeRegistrar) toolsetAllows(tool tools.Tool) bool {
-	active := safety.ParseToolset(string(r.toolset))
-	switch active {
-	case safety.ToolsetFull:
-		return true
-	case safety.ToolsetCompact:
-		return toolcatalog.IsCompactTool(tool.Name)
-	default:
-		return tool.EffectiveToolset() == safety.ToolsetCore
-	}
+	return toolexec.Allows(safety.NewCapability(safety.ModeFull), r.toolset, tool)
 }
 
 func (r *safeRegistrar) capabilityAllows(tool tools.Tool) bool {
-	capability := r.capability
-	if capability == nil {
-		capability = safety.NewCapability(safety.ModeSafe)
-	}
-	if tool.RequiresDelete() && !capability.CanDelete() {
-		return false
-	}
-	return !tool.RequiresWrite() || capability.CanWrite()
+	return toolexec.Allows(r.capability, safety.ToolsetFull, tool)
 }
 
 func (r *safeRegistrar) validateTool(tool tools.Tool) error {
@@ -380,13 +368,7 @@ func logToolHandlerError(logger *slog.Logger, toolName string, err error) {
 }
 
 func publicToolErrorMessage(err error) string {
-	if message, ok := tools.PublicErrorMessage(err); ok {
-		return message
-	}
-	if errors.Is(err, tools.ErrInvalidInput) {
-		return invalidInputToolErrorMessage
-	}
-	return genericToolErrorMessage
+	return toolexec.PublicErrorMessage(err)
 }
 
 func toolErrorResult(message string) *sdkmcp.CallToolResult {

--- a/internal/toolexec/executor.go
+++ b/internal/toolexec/executor.go
@@ -1,0 +1,104 @@
+// Package toolexec implements transport-neutral tool registration policy and execution.
+package toolexec
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/ricardocabral/icuvisor/internal/intervals"
+	"github.com/ricardocabral/icuvisor/internal/safety"
+	"github.com/ricardocabral/icuvisor/internal/toolcatalog"
+	"github.com/ricardocabral/icuvisor/internal/tools"
+)
+
+const (
+	// GenericErrorMessage is returned when a handler failure has no safe public detail.
+	GenericErrorMessage = "tool failed; try again or check icuvisor logs"
+	// InvalidInputErrorMessage is returned for unspecialized argument validation failures.
+	InvalidInputErrorMessage = "invalid tool arguments; check the inputs and try again"
+	// LocalModeAthleteTargetMessage explains why local calls cannot select another athlete.
+	LocalModeAthleteTargetMessage = "athlete_id is only supported when coach mode is enabled"
+)
+
+// Outcome contains a handler result and, on failure, both internal and public error forms.
+type Outcome struct {
+	Result        tools.Result
+	Err           error
+	PublicMessage string
+	Panicked      bool
+}
+
+// Execute invokes a tool with local-athlete routing and fail-safe panic recovery.
+// An empty localAthleteID means routing has already been resolved by the caller.
+func Execute(ctx context.Context, tool tools.Tool, request tools.Request, localAthleteID string) (out Outcome) {
+	defer func() {
+		if recover() != nil {
+			out = Outcome{
+				Err:           errors.New("tool handler panicked"),
+				PublicMessage: GenericErrorMessage,
+				Panicked:      true,
+			}
+		}
+	}()
+
+	if localAthleteID != "" && toolcatalog.IsAthleteScopedTool(tool.Name) {
+		if hasArgument(request.Arguments, "athlete_id") {
+			err := tools.NewUserError(LocalModeAthleteTargetMessage, tools.ErrInvalidInput)
+			return Outcome{Err: err, PublicMessage: PublicErrorMessage(err)}
+		}
+		ctx = intervals.WithTargetAthleteID(ctx, localAthleteID)
+	}
+	result, err := tool.Handler(ctx, request)
+	if err != nil {
+		return Outcome{Err: err, PublicMessage: PublicErrorMessage(err)}
+	}
+	return Outcome{Result: result}
+}
+
+// PublicErrorMessage returns the safe, actionable representation of a handler error.
+func PublicErrorMessage(err error) string {
+	if message, ok := tools.PublicErrorMessage(err); ok {
+		return message
+	}
+	if errors.Is(err, tools.ErrInvalidInput) {
+		return InvalidInputErrorMessage
+	}
+	return GenericErrorMessage
+}
+
+// Allows reports whether a tool passes the active capability and toolset gates.
+func Allows(capability safety.Capability, active safety.Toolset, tool tools.Tool) bool {
+	if capability == nil {
+		capability = safety.NewCapability(safety.ModeSafe)
+	}
+	if tool.RequiresDelete() && !capability.CanDelete() {
+		return false
+	}
+	if tool.RequiresWrite() && !capability.CanWrite() {
+		return false
+	}
+	switch safety.ParseToolset(active.String()) {
+	case safety.ToolsetFull:
+		return true
+	case safety.ToolsetCompact:
+		return toolcatalog.IsCompactTool(tool.Name)
+	default:
+		return tool.EffectiveToolset() == safety.ToolsetCore
+	}
+}
+
+func hasArgument(arguments json.RawMessage, name string) bool {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(arguments, &object); err != nil {
+		return false
+	}
+	_, ok := object[name]
+	return ok
+}
+
+// PublicError wraps a sanitized execution failure for non-MCP callers.
+func PublicError(toolName, message string) error {
+	return fmt.Errorf("calling %s: %s", toolName, message)
+}

--- a/internal/toolexec/executor_test.go
+++ b/internal/toolexec/executor_test.go
@@ -1,0 +1,37 @@
+package toolexec
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/ricardocabral/icuvisor/internal/tools"
+)
+
+func TestExecuteRejectsAthleteIDInLocalModeAsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	tool := tools.Tool{
+		Name: "get_athlete_profile",
+		Handler: func(context.Context, tools.Request) (tools.Result, error) {
+			called = true
+			return tools.Result{}, nil
+		},
+	}
+
+	out := Execute(context.Background(), tool, tools.Request{
+		Name:      tool.Name,
+		Arguments: json.RawMessage(`{"athlete_id":"i67890"}`),
+	}, "i12345")
+	if !errors.Is(out.Err, tools.ErrInvalidInput) {
+		t.Fatalf("error = %v, want ErrInvalidInput", out.Err)
+	}
+	if out.PublicMessage != LocalModeAthleteTargetMessage {
+		t.Fatalf("public message = %q, want %q", out.PublicMessage, LocalModeAthleteTargetMessage)
+	}
+	if called {
+		t.Fatal("handler was called")
+	}
+}

--- a/pkg/icuvisor/icuvisor.go
+++ b/pkg/icuvisor/icuvisor.go
@@ -4,10 +4,13 @@ package icuvisor
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"slices"
+	"strings"
 	"time"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -18,6 +21,7 @@ import (
 	"github.com/ricardocabral/icuvisor/internal/prompts"
 	"github.com/ricardocabral/icuvisor/internal/resources"
 	"github.com/ricardocabral/icuvisor/internal/safety"
+	"github.com/ricardocabral/icuvisor/internal/toolexec"
 	"github.com/ricardocabral/icuvisor/internal/tools"
 )
 
@@ -199,6 +203,122 @@ type Server struct {
 	inner *internalmcp.Server
 }
 
+// Invoker invokes registered core tools without an MCP transport.
+type Invoker struct {
+	tools       map[string]tools.Tool
+	athleteID   string
+	version     string
+	deleteMode  DeleteMode
+	toolset     Toolset
+	catalogHash string
+}
+
+// InvokerOptions configures direct core-tool invocation for local CLI and agent views.
+type InvokerOptions struct {
+	Config     Config
+	Registry   Registry
+	Version    string
+	DeleteMode DeleteMode
+	Toolset    Toolset
+}
+
+// NewInvoker constructs a direct invoker from the same registry and safety policy used by MCP.
+func NewInvoker(ctx context.Context, opts InvokerOptions) (*Invoker, error) {
+	cfg, err := opts.Config.toInternalValidated()
+	if err != nil {
+		return nil, err
+	}
+	deleteMode, toolset, err := effectivePolicy(opts.DeleteMode, opts.Toolset, opts.Config)
+	if err != nil {
+		return nil, err
+	}
+	registry := registryForConfig(opts.Registry, opts.Config)
+	if registry == nil {
+		return nil, errors.New("creating invoker: missing tool registry")
+	}
+	capability := safety.NewCapability(deleteMode.toInternal())
+	catalogHash, err := internalmcp.ComputeToolCatalogHash(ctx, internalmcp.CatalogHashOptions{
+		Config:     cfg,
+		Registry:   registry,
+		Capability: capability,
+		Toolset:    toolset.toInternal(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if opts.Registry.core != nil {
+		registry = registryForConfigWithCatalogHash(opts.Registry, opts.Config, catalogHash)
+	}
+	registrar := directRegistrar{
+		tools:      make(map[string]tools.Tool),
+		capability: capability,
+		toolset:    toolset.toInternal(),
+	}
+	if err := registry.Register(ctx, &registrar); err != nil {
+		return nil, err
+	}
+	version := strings.TrimSpace(opts.Version)
+	if version == "" {
+		version = "dev"
+	}
+	return &Invoker{tools: registrar.tools, athleteID: cfg.AthleteID, version: version, deleteMode: deleteMode, toolset: toolset, catalogHash: catalogHash}, nil
+}
+
+// Tools returns the tools available to this direct invocation view.
+func (i *Invoker) Tools() []ToolInfo {
+	if i == nil {
+		return nil
+	}
+	out := make([]ToolInfo, 0, len(i.tools))
+	for _, tool := range i.tools {
+		out = append(out, toolInfoFromInternal(tool))
+	}
+	slices.SortFunc(out, func(a, b ToolInfo) int { return strings.Compare(a.Name, b.Name) })
+	return out
+}
+
+// Info returns non-secret metadata about this direct invocation view.
+func (i *Invoker) Info() InvokerInfo {
+	if i == nil {
+		return InvokerInfo{}
+	}
+	return InvokerInfo{Version: i.version, DeleteMode: i.deleteMode, Toolset: i.toolset, CatalogHash: i.catalogHash}
+}
+
+// Invoke calls one registered tool without an MCP transport.
+func (i *Invoker) Invoke(ctx context.Context, name string, arguments json.RawMessage) (ToolResult, error) {
+	if i == nil {
+		return ToolResult{}, errors.New("invoking tool: nil invoker")
+	}
+	tool, ok := i.tools[name]
+	if !ok {
+		return ToolResult{}, fmt.Errorf("unknown or unavailable tool %q", name)
+	}
+	outcome := toolexec.Execute(ctx, tool, tools.Request{Name: name, Arguments: arguments}, i.athleteID)
+	if outcome.Err != nil {
+		return ToolResult{}, toolexec.PublicError(name, outcome.PublicMessage)
+	}
+	return toolResultFromInternal(outcome.Result), nil
+}
+
+// directRegistrar applies the same registration-time safety and toolset policy as MCP.
+type directRegistrar struct {
+	tools      map[string]tools.Tool
+	capability safety.Capability
+	toolset    safety.Toolset
+}
+
+func (r *directRegistrar) AddTool(tool tools.Tool) error {
+	if _, exists := r.tools[tool.Name]; exists {
+		return fmt.Errorf("duplicate tool name %q", tool.Name)
+	}
+	if !toolexec.Allows(r.capability, r.toolset, tool) {
+		return nil
+	}
+	r.tools[tool.Name] = tool
+	return nil
+}
+
 // ServerOptions configures core MCP server construction.
 type ServerOptions struct {
 	Config                     Config
@@ -312,14 +432,35 @@ func ComputeToolCatalogHash(ctx context.Context, opts CatalogOptions) (string, e
 	return internalmcp.ComputeToolCatalogHash(ctx, internalmcp.CatalogHashOptions{Config: cfg, Registry: registryForConfig(opts.Registry, opts.Config), Capability: safety.NewCapability(deleteMode.toInternal()), Toolset: toolset.toInternal(), Logger: opts.Logger})
 }
 
-// ToolInfo is public non-secret metadata about a registered tool.
+// InvokerInfo is non-secret metadata about a direct invocation view.
+type InvokerInfo struct {
+	Version     string     `json:"version"`
+	DeleteMode  DeleteMode `json:"delete_mode"`
+	Toolset     Toolset    `json:"toolset"`
+	CatalogHash string     `json:"catalog_hash"`
+}
+
+// ToolInfo is the canonical MCP descriptor plus CLI-only metadata.
 type ToolInfo struct {
-	Name         string
-	Description  string
-	InputSchema  any
-	OutputSchema any
-	Requirement  Requirement
-	Toolset      Toolset
+	Name         string                  `json:"name"`
+	Description  string                  `json:"description"`
+	InputSchema  any                     `json:"inputSchema"`
+	OutputSchema any                     `json:"outputSchema,omitempty"`
+	Annotations  *sdkmcp.ToolAnnotations `json:"annotations,omitempty"`
+	Meta         ToolInfoMeta            `json:"_meta"`
+	Requirement  Requirement             `json:"-"`
+	Toolset      Toolset                 `json:"-"`
+}
+
+// ToolInfoMeta contains metadata outside the MCP tool descriptor contract.
+type ToolInfoMeta struct {
+	ICUvisor ToolMetadata `json:"icuvisor"`
+}
+
+// ToolMetadata describes a tool's registration tier and safety class.
+type ToolMetadata struct {
+	Toolset Toolset     `json:"toolset"`
+	Safety  Requirement `json:"safety"`
 }
 
 // Tool is a public custom tool definition for host diagnostics and policy extensions.
@@ -429,6 +570,14 @@ func internalResult(result ToolResult) tools.Result {
 	return tools.Result{Content: content, StructuredContent: result.StructuredContent, IsError: result.IsError}
 }
 
+func toolResultFromInternal(result tools.Result) ToolResult {
+	content := make([]Content, 0, len(result.Content))
+	for _, item := range result.Content {
+		content = append(content, Content{Type: ContentType(item.Type), Text: item.Text})
+	}
+	return ToolResult{Content: content, StructuredContent: result.StructuredContent, IsError: result.IsError}
+}
+
 func internalToolFilter(filter func(ToolInfo) bool) func(tools.Tool) bool {
 	if filter == nil {
 		return nil
@@ -439,7 +588,18 @@ func internalToolFilter(filter func(ToolInfo) bool) func(tools.Tool) bool {
 }
 
 func toolInfoFromInternal(tool tools.Tool) ToolInfo {
-	return ToolInfo{Name: tool.Name, Description: tool.Description, InputSchema: tool.InputSchema, OutputSchema: tool.OutputSchema, Requirement: requirementFromInternal(tool), Toolset: Toolset(tool.EffectiveToolset().String())}
+	requirement := requirementFromInternal(tool)
+	toolset := Toolset(tool.EffectiveToolset().String())
+	return ToolInfo{
+		Name:         tool.Name,
+		Description:  tool.Description,
+		InputSchema:  tool.InputSchema,
+		OutputSchema: tool.OutputSchema,
+		Annotations:  internalmcp.SDKToolAnnotations(tool),
+		Meta:         ToolInfoMeta{ICUvisor: ToolMetadata{Toolset: toolset, Safety: requirement}},
+		Requirement:  requirement,
+		Toolset:      toolset,
+	}
 }
 
 func requirementFromInternal(tool tools.Tool) Requirement {

--- a/pkg/icuvisor/icuvisor_test.go
+++ b/pkg/icuvisor/icuvisor_test.go
@@ -603,6 +603,145 @@ func TestStreamableHTTPHandlerFacadeDefaultsToPublicFactoryError(t *testing.T) {
 	}
 }
 
+func TestDirectInvokerUsesMCPRegistrationPolicyAndHandlers(t *testing.T) {
+	t.Parallel()
+
+	client := newFacadeTestClient(t)
+	registry := NewCoreRegistry(client, RegistryOptions{
+		Version: "v-public",
+		ExtraTools: []Tool{{
+			Name:         "direct_echo",
+			Description:  "Returns its arguments for direct-invocation coverage.",
+			InputSchema:  map[string]any{"type": "object"},
+			OutputSchema: map[string]any{"type": "object"},
+			Requirement:  RequirementRead,
+			Toolset:      ToolsetCore,
+			Handler: func(_ context.Context, req ToolRequest) (ToolResult, error) {
+				return TextResult(map[string]string{"name": req.Name, "arguments": string(req.Arguments)}), nil
+			},
+		}},
+	})
+	cfg := facadeTestConfig()
+	invoker, err := NewInvoker(context.Background(), InvokerOptions{Config: cfg, Registry: registry, DeleteMode: DeleteModeSafe, Toolset: ToolsetCore})
+	if err != nil {
+		t.Fatalf("NewInvoker() error = %v", err)
+	}
+	if !hasTool(invoker.Tools(), "direct_echo") {
+		t.Fatal("direct invoker catalog missing extra core tool")
+	}
+	result, err := invoker.Invoke(context.Background(), "direct_echo", json.RawMessage(`{"message":"hello"}`))
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatal("Invoke() returned an error result")
+	}
+	payload, ok := result.StructuredContent.(map[string]string)
+	if !ok || payload["name"] != "direct_echo" || payload["arguments"] != `{"message":"hello"}` {
+		t.Fatalf("Invoke() result = %#v, want direct handler result", result.StructuredContent)
+	}
+	if _, err := invoker.Invoke(context.Background(), "delete_event", json.RawMessage(`{}`)); err == nil {
+		t.Fatal("safe direct invoker exposed delete_event")
+	}
+}
+
+func TestDirectInvokerSanitizesHandlerErrorsAndPanics(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		handler Handler
+		want    string
+	}{
+		{
+			name: "raw error",
+			handler: func(context.Context, ToolRequest) (ToolResult, error) {
+				return ToolResult{}, errors.New("secret upstream detail")
+			},
+			want: "tool failed; try again or check icuvisor logs",
+		},
+		{
+			name: "public error",
+			handler: func(context.Context, ToolRequest) (ToolResult, error) {
+				return ToolResult{}, NewUserError("use a supported value", errors.New("secret cause"))
+			},
+			want: "use a supported value",
+		},
+		{
+			name: "panic",
+			handler: func(context.Context, ToolRequest) (ToolResult, error) {
+				panic("secret panic value")
+			},
+			want: "tool failed; try again or check icuvisor logs",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tool := facadeExtraTool("Failure parity tool.", ToolsetCore)
+			tool.Handler = tc.handler
+			registry := NewCoreRegistry(newFacadeTestClient(t), RegistryOptions{Version: "v-public", ExtraTools: []Tool{tool}})
+			invoker, err := NewInvoker(context.Background(), InvokerOptions{Config: facadeTestConfig(), Registry: registry})
+			if err != nil {
+				t.Fatalf("NewInvoker() error = %v", err)
+			}
+			_, err = invoker.Invoke(context.Background(), tool.Name, json.RawMessage(`{}`))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Invoke() error = %v, want %q", err, tc.want)
+			}
+			if strings.Contains(err.Error(), "secret") {
+				t.Fatalf("Invoke() leaked internal detail: %v", err)
+			}
+		})
+	}
+}
+
+func TestDirectInvokerRejectsMissingRegistry(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewInvoker(context.Background(), InvokerOptions{Config: facadeTestConfig()}); err == nil || !strings.Contains(err.Error(), "missing tool registry") {
+		t.Fatalf("NewInvoker() error = %v, want missing-registry error", err)
+	}
+}
+
+func TestDirectInvokerRoutesConfiguredAthleteAndRejectsArgumentOverride(t *testing.T) {
+	t.Parallel()
+
+	invoker, err := NewInvoker(context.Background(), InvokerOptions{
+		Config:   facadeTestConfig(),
+		Registry: Registry{inner: directTargetTestRegistry{}},
+	})
+	if err != nil {
+		t.Fatalf("NewInvoker() error = %v", err)
+	}
+	result, err := invoker.Invoke(context.Background(), "get_athlete_profile", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	payload, ok := result.StructuredContent.(map[string]string)
+	if !ok || payload["target_athlete_id"] != "i12345" {
+		t.Fatalf("Invoke() result = %#v, want configured athlete target", result.StructuredContent)
+	}
+	if _, err := invoker.Invoke(context.Background(), "get_athlete_profile", json.RawMessage(`{"athlete_id":"i99999"}`)); err == nil || !strings.Contains(err.Error(), "athlete_id is only supported") {
+		t.Fatalf("Invoke() athlete_id error = %v, want local-mode rejection", err)
+	}
+}
+
+type directTargetTestRegistry struct{}
+
+func (directTargetTestRegistry) Register(_ context.Context, registrar internaltools.Registrar) error {
+	return registrar.AddTool(internaltools.Tool{
+		Name:         "get_athlete_profile",
+		Description:  "Direct target routing test tool.",
+		InputSchema:  map[string]any{"type": "object"},
+		OutputSchema: map[string]any{"type": "object"},
+		Toolset:      safety.ToolsetCore,
+		Handler: func(ctx context.Context, _ internaltools.Request) (internaltools.Result, error) {
+			targetAthleteID, _ := intervals.TargetAthleteIDFromContext(ctx)
+			return internaltools.TextResult(map[string]string{"target_athlete_id": targetAthleteID}), nil
+		},
+	})
+}
+
 func newHTTPFacadeTestClient(t *testing.T, cfg Config) *Client {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/web/content/reference/cli.md
+++ b/web/content/reference/cli.md
@@ -7,6 +7,36 @@ The icuvisor binary is both the MCP server and the setup/diagnostics CLI. Runnin
 
 Use this page when you need the exact command-line surface. The full output below is rendered from `internal/app/testdata/help.golden`, which is the CLI golden fixture used by tests.
 
+## Standalone direct-tool CLI
+
+`icuvisor-cli` is a separate binary for local users, scripts, and agents that prefer commands over MCP tool registration. It invokes the same safety-gated core handlers as the MCP binary, but does not start an MCP transport.
+
+```sh
+icuvisor-cli capabilities
+icuvisor-cli doctor
+icuvisor-cli tools list
+icuvisor-cli tools describe get_today
+icuvisor-cli tools call get_today --args '{}'
+echo '{}' | icuvisor-cli tools call get_today --args-file -
+```
+
+- `tools list` writes compact entries (`name`, summary, toolset, safety) plus a version/toolset/delete-mode/catalog-hash header.
+- `tools describe <tool>` writes the canonical MCP descriptor (`name`, `description`, `inputSchema`, `outputSchema`, `annotations`) plus CLI metadata under `_meta.icuvisor`.
+- `tools call <tool>` writes bare structured content, without an MCP envelope. Supply one JSON object with `--args <json>`, `--args-file <path>`, or `--args-file -` for stdin; omitted arguments default to `{}`.
+- `doctor` reports redacted config/auth/reachability readiness without credentials or raw athlete IDs.
+- `capabilities` reports contract version, active gates, catalog hash, and supported surfaces. This MVP supports Tools; Resources and Prompts are required follow-ups.
+- Success writes to stdout only. Failure leaves stdout empty and writes one JSON object to stderr, without ANSI formatting.
+- API keys remain configuration/keychain inputs and are never flags or tool arguments.
+- The standalone CLI uses the configured local athlete only; effective coach mode fails closed and remains MCP-only.
+
+### `icuvisor-cli` exit codes
+
+| Code | Meaning |
+| ---- | ------- |
+| `0` | Success, including help and version output. |
+| `2` | Usage error, such as an unknown command/flag or invalid argument JSON. |
+| `1` | Runtime error, such as config, reachability, or tool execution failure. |
+
 ## Commands
 
 | Command                                           | What it does                                                                                                                                      |


### PR DESCRIPTION
## Summary

- ship `icuvisor-cli` alongside the MCP binary using the existing build, signing, packaging, and release flow
- expose the tools-only MVP through namespaced `tools list`, `tools describe`, and `tools call` commands, plus `doctor` and `capabilities`
- share local-athlete routing, registration gates, public-error sanitization, and per-call panic recovery between MCP and direct invocation
- add compact progressive catalog discovery, canonical MCP descriptors, stdin JSON arguments, and deterministic machine-readable process errors
- address review feedback for command parsing, local-athlete validation classification, Windows installer metadata, and public-core verification guidance

Resources and Prompts are explicitly reported as unsupported surfaces in this tools-only MVP and remain follow-up work.

## Process contract

- successful commands write JSON to stdout only
- failures leave stdout empty and write one JSON error to stderr
- exit code `2` identifies usage errors; exit code `1` identifies runtime errors
- API credentials remain configuration/keychain inputs and are never accepted as CLI flags or tool arguments
- effective coach mode fails closed because the standalone CLI is local-athlete-only

## Validation

- `make build`
- `go test ./...`
- `make test-race`
- `make lint`
- `make docs-tools` (clean catalog output)
- `git diff --check`

## Live CLI evidence

Using locally configured development intervals.icu credentials, these commands all returned exit `0`, valid JSON on stdout, and empty stderr:

```text
icuvisor-cli doctor
icuvisor-cli tools call get_athlete_profile --args '{}'
icuvisor-cli tools call get_today --args '{}'
```

The terse `get_today` response contained the expected sections and metadata:

```json
{
  "date": "2026-07-21",
  "fitness": [],
  "completed_activities": [],
  "planned_events": [],
  "wellness": [{
    "ctl": 41.386703,
    "atl": 28.980162,
    "hrv": 40,
    "restingHR": 49,
    "sleepQuality": 2,
    "sleepScore": 87,
    "sleepSecs": 29160,
    "steps": 8979
  }],
  "weather": {"status": "forecast_unavailable"},
  "_meta": {"timezone": "US/Pacific", "units": {"system": "metric"}}
}
```
