### PR TITLE
fix(analyzers): request wellness id column so daily metrics resolve dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Analyzer and baseline tools now request the wellness `id` date column alongside the metric field, so wellness-sourced metrics (`hrv`, `rhr`, `sleep_secs`, and every other daily wellness metric) return real samples instead of silently reporting zero; HRV-family metrics fetch full rows so provider provenance staleness detection works as designed.
+
 ## [1.5.4] - 2026-08-03
 
 ### Added

--- a/internal/tools/analyze_common.go
+++ b/internal/tools/analyze_common.go
@@ -87,7 +87,7 @@ func loadAnalyzerSeries(ctx context.Context, clients analyzerClients, metric ana
 		if clients.wellness == nil {
 			return series, errors.New("missing wellness client")
 		}
-		rows, err := clients.wellness.ListWellness(ctx, intervals.WellnessParams{Oldest: window.StartDate, Newest: window.EndDate, Fields: []string{selection.Source.Field}})
+		rows, err := clients.wellness.ListWellness(ctx, intervals.WellnessParams{Oldest: window.StartDate, Newest: window.EndDate, Fields: analyzerWellnessFields(metric, selection.Source.Field)})
 		if err != nil {
 			return series, err
 		}

--- a/internal/tools/analyzer_regression_test.go
+++ b/internal/tools/analyzer_regression_test.go
@@ -250,6 +250,71 @@ func TestAnalyzeTrendHRVStaleProvenanceVisible(t *testing.T) {
 	}
 }
 
+func TestAnalyzerWellnessFieldsAlwaysRequestDateColumn(t *testing.T) {
+	if got := analyzerWellnessFields(analysis.Metric("rhr"), "restingHR"); !slices.Equal(got, []string{"id", "restingHR"}) {
+		t.Fatalf("analyzerWellnessFields(rhr) = %#v, want id plus metric field", got)
+	}
+	for _, metric := range []string{"hrv", "hrv_sdnn"} {
+		if got := analyzerWellnessFields(analysis.Metric(metric), metric); got != nil {
+			t.Fatalf("analyzerWellnessFields(%s) = %#v, want nil for full rows with provenance", metric, got)
+		}
+	}
+}
+
+func TestAnalyzeTrendWellnessMetricSurvivesUpstreamFieldFilter(t *testing.T) {
+	client := newFakeComputeClient()
+	client.wellness = []intervals.Wellness{
+		decodeWellnessRow(t, `{"id":"2026-05-01","restingHR":50}`),
+		decodeWellnessRow(t, `{"id":"2026-05-02","restingHR":51}`),
+		decodeWellnessRow(t, `{"id":"2026-05-03","restingHR":52}`),
+		decodeWellnessRow(t, `{"id":"2026-05-04","restingHR":53}`),
+		decodeWellnessRow(t, `{"id":"2026-05-05","restingHR":54}`),
+		decodeWellnessRow(t, `{"id":"2026-05-06","restingHR":55}`),
+		decodeWellnessRow(t, `{"id":"2026-05-07","restingHR":56}`),
+	}
+	tool := newAnalyzeTrendTool(nil, client, nil, client, "test", "UTC", false)
+
+	result, err := tool.Handler(context.Background(), Request{Name: tool.Name, Arguments: json.RawMessage(`{"metric":"rhr","window":{"start_date":"2026-05-01","end_date":"2026-05-07"}}`)})
+	if err != nil {
+		t.Fatalf("Handler() error = %v", err)
+	}
+	meta := resultMap(t, result)["_meta"].(map[string]any)
+	if meta["n"] != float64(7) || meta["missing_days"] != float64(0) {
+		t.Fatalf("meta n=%v missing_days=%v, want 7 samples and no missing days despite upstream field filter", meta["n"], meta["missing_days"])
+	}
+	if len(client.wellnessCalls) == 0 {
+		t.Fatal("no wellness calls recorded")
+	}
+	for _, call := range client.wellnessCalls {
+		if !slices.Contains(call.Fields, "id") {
+			t.Fatalf("wellness fields = %#v, want id requested so sample dates resolve", call.Fields)
+		}
+	}
+}
+
+func TestAnalyzeTrendHRVFetchesFullRowsForProvenance(t *testing.T) {
+	client := newFakeComputeClient()
+	client.wellness = []intervals.Wellness{
+		decodeWellnessRow(t, `{"id":"2026-05-01","hrv":76}`),
+		decodeWellnessRow(t, `{"id":"2026-05-02","hrv":77}`),
+	}
+	tool := newAnalyzeTrendTool(nil, client, nil, client, "test", "UTC", false)
+
+	result, err := tool.Handler(context.Background(), Request{Name: tool.Name, Arguments: json.RawMessage(`{"metric":"hrv","window":{"start_date":"2026-05-01","end_date":"2026-05-02"},"rolling_window_days":2}`)})
+	if err != nil {
+		t.Fatalf("Handler() error = %v", err)
+	}
+	meta := resultMap(t, result)["_meta"].(map[string]any)
+	if meta["n"] != float64(2) {
+		t.Fatalf("meta n=%v, want 2 HRV samples", meta["n"])
+	}
+	for _, call := range client.wellnessCalls {
+		if len(call.Fields) != 0 {
+			t.Fatalf("wellness fields = %#v, want full rows so provider provenance sidecars survive", call.Fields)
+		}
+	}
+}
+
 func TestAnalyzeTrendPropagatesBaselineCancellation(t *testing.T) {
 	client := &cancelSecondSummaryClient{rows: decodeSummaries(t, `[
 		{"date":"2026-05-01","fitness":70},{"date":"2026-05-02","fitness":71},{"date":"2026-05-03","fitness":72},{"date":"2026-05-04","fitness":73},{"date":"2026-05-05","fitness":74},{"date":"2026-05-06","fitness":75},{"date":"2026-05-07","fitness":76}

--- a/internal/tools/analyzer_sources.go
+++ b/internal/tools/analyzer_sources.go
@@ -167,6 +167,18 @@ func (s *wellnessFreshnessSummary) trendAssumptions() map[string]any {
 	return out
 }
 
+// analyzerWellnessFields returns the upstream field filter for analyzer wellness
+// fetches. The id column carries the row date and must always be requested
+// alongside the metric field; intervals.icu omits it (and every other column)
+// from filtered responses. Metrics with freshness tracking fetch full rows
+// because provenance lives in provider sidecar fields the filter would strip.
+func analyzerWellnessFields(metric analysis.Metric, field string) []string {
+	if _, _, ok := wellnessFreshnessField(metric); ok {
+		return nil
+	}
+	return []string{"id", field}
+}
+
 func wellnessFreshnessField(metric analysis.Metric) (string, string, bool) {
 	switch metric {
 	case "hrv":

--- a/internal/tools/compute_baseline.go
+++ b/internal/tools/compute_baseline.go
@@ -252,7 +252,7 @@ func collectSummaryBaseline(ctx context.Context, args computeBaselineRequest, me
 }
 
 func collectWellnessBaseline(ctx context.Context, args computeBaselineRequest, metric analysis.Metric, source analysis.MetricSource, client WellnessClient) (baselineCollected, error) {
-	rows, err := client.ListWellness(ctx, intervals.WellnessParams{Oldest: args.BaselineStartDate, Newest: args.CurrentEndDate, Fields: []string{source.Field}})
+	rows, err := client.ListWellness(ctx, intervals.WellnessParams{Oldest: args.BaselineStartDate, Newest: args.CurrentEndDate, Fields: analyzerWellnessFields(metric, source.Field)})
 	if err != nil {
 		return baselineCollected{}, err
 	}

--- a/internal/tools/compute_tools_test.go
+++ b/internal/tools/compute_tools_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -26,6 +27,7 @@ type fakeComputeClient struct {
 	activityCalls int
 	detailCalls   []string
 	intervalCalls int
+	wellnessCalls []intervals.WellnessParams
 }
 
 func newFakeComputeClient() *fakeComputeClient {
@@ -72,6 +74,7 @@ func (c *fakeComputeClient) GetActivityPowerVsHR(context.Context, string) (inter
 }
 
 func (c *fakeComputeClient) ListWellness(_ context.Context, params intervals.WellnessParams) ([]intervals.Wellness, error) {
+	c.wellnessCalls = append(c.wellnessCalls, params)
 	rows := make([]intervals.Wellness, 0, len(c.wellness))
 	for _, row := range c.wellness {
 		date := wellnessDate(row)
@@ -81,9 +84,32 @@ func (c *fakeComputeClient) ListWellness(_ context.Context, params intervals.Wel
 		if params.Newest != "" && date > params.Newest {
 			continue
 		}
-		rows = append(rows, row)
+		rows = append(rows, filterWellnessRowFields(row, params.Fields))
 	}
 	return rows, nil
+}
+
+// filterWellnessRowFields mimics intervals.icu column filtering: a non-empty
+// fields list drops every other column from the row, including id.
+func filterWellnessRowFields(row intervals.Wellness, fields []string) intervals.Wellness {
+	if len(fields) == 0 {
+		return row
+	}
+	filtered := map[string]any{}
+	for _, field := range fields {
+		if value, ok := row.Raw[field]; ok {
+			filtered[field] = value
+		}
+	}
+	data, err := json.Marshal(filtered)
+	if err != nil {
+		return intervals.Wellness{}
+	}
+	var out intervals.Wellness
+	if err := json.Unmarshal(data, &out); err != nil {
+		return intervals.Wellness{}
+	}
+	return out
 }
 
 func (c *fakeComputeClient) ListEvents(context.Context, intervals.ListEventsParams) ([]intervals.Event, error) {


### PR DESCRIPTION
## Summary

- Every wellness-only analyzer metric (`hrv`, `rhr`, `sleep_secs`, ...) silently returned `n: 0` because the analyzer fetched wellness rows with a single-column `fields` filter, and intervals.icu drops all other columns from filtered responses, including the `id` date column; every sample was then discarded for having no date.
- `analyze_trend`/`analyze_distribution`/`analyze_correlation`/`compute_baseline` now request `id` alongside the metric field; HRV-family metrics fetch full rows because the freshness provenance tracker reads provider sidecar fields the filter also stripped (so staleness detection now works as designed too).
- The shared test fake now mimics upstream column filtering (it previously ignored the `fields` parameter, which is what masked the bug), plus regression tests asserting samples survive the filter.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation only
- [ ] CI / build / chore

## Related issues

Closes #51

## Testing

Reproduced live via Claude Code against v1.5.4: `analyze_trend` with `metric: "rhr"` returned `n: 0` over a window where `get_wellness_data` shows resting HR values of 47/41/45, and `get_wellness_data` with `fields: ["hrv"]` returns bare `{"hrv": 66}` rows with no `id`, confirming the mechanism. Regression tests fail against the old behaviour with the exact production symptom (`n=0`, `missing_days=7`).

- [x] `make test` passes (full suite; the only local failures are the two `TestCustomItemByIDLiveProbeScript*` tests, which also fail on pristine `main` on this Windows machine because its WSL has no `/bin/bash` -- unrelated to this change)
- [x] `make lint` passes (golangci-lint 2.12.2, 0 issues)
- [x] Added or updated tests where applicable
- [x] Manual test with at least one MCP client (Claude Code on Windows, against a local build containing this fix together with #55/#56: `analyze_trend` with `hrv` over `2026-06-13..2026-08-08` now returns n=54 rMSSD samples where v1.5.4 returned n=0/missing_days=57, and `rhr` returns n=8 matching `get_wellness_data` values)

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `CHANGELOG.md` updated under `[Unreleased]` if user-visible
- [x] Docs updated if behaviour or config changed (no doc changes needed; no schema changes)
- [x] No GPL-licensed code copied into this PR

Generated with [Claude Code](https://claude.com/claude-code)