### PR TITLE
chore(toolcatalog): refresh schema snapshots

### DIFF
--- a/internal/tools/schema_snapshot/get_gear_list.json
+++ b/internal/tools/schema_snapshot/get_gear_list.json
@@ -7,7 +7,7 @@
     },
     "include_full": {
       "default": false,
-      "description": "When true, include raw upstream gear fields under each row's full object; default terse rows include gear_id, name/name_missing, type, brand, model, and retired.",
+      "description": "When true, include raw upstream gear fields under each row's full object; default terse rows include gear_id, name/name_missing, type, and retired.",
       "type": "boolean"
     },
     "refresh": {

--- a/internal/tools/schema_snapshot/update_wellness.json
+++ b/internal/tools/schema_snapshot/update_wellness.json
@@ -3,7 +3,8 @@
   "examples": [
     {
       "date": "2026-06-15",
-      "fatigue": 2
+      "fatigue": 2,
+      "hydration": 3
     },
     {
       "date": "2026-06-16",
@@ -32,7 +33,8 @@
   "input_examples": [
     {
       "date": "2026-06-15",
-      "fatigue": 2
+      "fatigue": 2,
+      "hydration": 3
     },
     {
       "date": "2026-06-16",
@@ -104,6 +106,12 @@
       "description": "Manual HRV in milliseconds rMSSD.",
       "minimum": 0,
       "type": "number"
+    },
+    "hydration": {
+      "description": "1-4 (athlete-reported hydration); hydration scale.",
+      "maximum": 4,
+      "minimum": 1,
+      "type": "integer"
     },
     "include_full": {
       "default": false,


### PR DESCRIPTION
Refresh the committed get_gear_list and update_wellness schema snapshots so they match the canonical live registry. The stale snapshots caused the Tool catalog guards job to fail on main and on unrelated pull requests. Verified with the schema-stability guard, go test ./..., and make lint.